### PR TITLE
Feature/25.2/0008463 rcs accessibility

### DIFF
--- a/plugins/mel_cal_resources/js/lib/resource_base.js
+++ b/plugins/mel_cal_resources/js/lib/resource_base.js
@@ -319,8 +319,6 @@ class ResourcesBase extends MelObject {
     try {
       $fc.css('width', '100%').fullCalendar(config);
       $fc.fullCalendar('render');
-      //$fc.fullCalendar('option', 'height', 200);
-      //$fc.fullCalendar('render');
     } catch (error) {
       console.error(error);
     }

--- a/plugins/mel_cal_resources/js/lib/resource_location.js
+++ b/plugins/mel_cal_resources/js/lib/resource_location.js
@@ -164,8 +164,34 @@ class ResourceLocation extends AExternalLocationPart {
     return this;
   }
 
+  /**
+   * Action du bouton pour ouvrir l'agenda de ressource.
+   *
+   * Sera utilisé par le bouton dans le template {@link ResourceLocation.page}
+   * @return {Promise<void>}
+   * @async
+   */
+  async action_rcs_button_click() {
+    await (await this.dialog.try_init()).show();
+    this.onclickafter.call();
+  }
+
+  /**
+   * Ouvre l'agenda de ressource
+   *
+   * Invoke {@link ResourceLocation.action_rcs_button_click} mais le thisargs est la page car c'est la page qui contient la dialog.
+   * @return {Promise<void>}
+   * @async
+   * @private
+   */
+  async #_rcs_button_action() {
+    return await this.action_rcs_button_click.call(this.page);
+  }
+
   changed_to_this() {
-    if (!window.start_planify) this.force_click();
+    if (!window.start_planify) {
+      this.#_rcs_button_action();
+    }
   }
 
   /**

--- a/plugins/mel_cal_resources/skins/mel_elastic/js_template/resource_location.js
+++ b/plugins/mel_cal_resources/skins/mel_elastic/js_template/resource_location.js
@@ -51,10 +51,7 @@ class ResourceDialogPage {
       })
         .button({
           type: 'button',
-          onclick:async () => {
-              await (await this.dialog.try_init()).show();
-              this.onclickafter.call();
-          }
+          onclick:resource.action_rcs_button_click.bind(this)
         }).addClass(resaData || false ? 'disabled' : EMPTY_STRING)
           .attr(resaData || false ? 'disabled' : 'waitingclick', resaData || false ? 'disabled' : 'true')
           .icon(resaData || false ? '' : 'ads_click').addClass(resaData || false ? 'clock-loader' : EMPTY_STRING)


### PR DESCRIPTION
"En utilisant la tabulation et nvda pour l'accessibilité, le clic sur planifier ouvre la modale pour le choix FLEX OFFICE de la ville, et la ressource souhaitée avec le créneau

La lecture avec nvda reprend en premier lieu le contenu de la modale principale de création de l'evt qui est en arrière plan, et en second temps la modale des ressources

Faire en sorte d'inverser la priorisation de lecture "

- L'action est désormais gérer par la ressource
- La ressource appelle désormait l'action
- Au lieu de cliquer sur le bouton au changement de type d'évènement, on appelle la fonction, ce qui permet d'éviter certains comportements avec des lecteurs d'écrans.

FIX: MANTIS 0008758