### PR TITLE
feat(rcs): Ressources : faire en sorte que fullcalendar n'affiche qu'un créneau horaire et pas 24h

### DIFF
--- a/plugins/mel_cal_resources/js/lib/resource_base.js
+++ b/plugins/mel_cal_resources/js/lib/resource_base.js
@@ -280,6 +280,18 @@ class ResourcesBase extends MelObject {
   }
 
   /**
+   * Renvoie une heure au format HH:mm
+   * @param {number} hour
+   * @returns {string} format HH:mm
+   * @private
+   */
+  #_set_buisness_hour(hour) {
+    if (hour < 10) hour = `0${hour}`;
+
+    return `${hour}:00`;
+  }
+
+  /**
    * Génère l'agenda avec fullcalendar
    * @package
    * @param {external:jQuery} $fc Div qui contient le fullcalendar
@@ -299,6 +311,8 @@ class ResourcesBase extends MelObject {
       schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
       height: 200,
       firstHour: settings.first_hour,
+      minTime: this.#_set_buisness_hour(settings.work_start),
+      maxTime: this.#_set_buisness_hour(settings.work_end),
       scrollTime: { hours: settings.first_hour },
       slotDuration: { minutes: 60 },
       locale: 'fr',
@@ -373,6 +387,39 @@ class ResourcesBase extends MelObject {
   }
 
   /**
+   * Met les input en rouge si la date n'est pas bonne
+   * @private
+   */
+  _set_validity() {
+    if (!$('.input-time-end')[0].checkValidity())
+      $('.input-time-end').addClass('is-invalid');
+    else $('.input-time-end').removeClass('is-invalid');
+
+    if (!$('.input-time-start')[0].checkValidity())
+      $('.input-time-start').addClass('is-invalid');
+    else $('.input-time-start').removeClass('is-invalid');
+
+    if (this._has_invalid()) {
+      $('.ui-dialog .save-btn')
+        .addClass('disabled')
+        .attr('disabled', 'disabled');
+    } else {
+      $('.ui-dialog .save-btn').removeClass('disabled').removeAttr('disabled');
+    }
+  }
+
+  /**
+   * Check si les input de temps sont valides ou non
+   * @returns {boolean}
+   */
+  _has_invalid() {
+    return (
+      !$('.input-time-end')[0].checkValidity() ||
+      !$('.input-time-start')[0].checkValidity()
+    );
+  }
+
+  /**
    * Fonction get pour la page de dialog retournée
    * @package
    * @param {Function} old Ancienne fonction get bind
@@ -386,6 +433,13 @@ class ResourcesBase extends MelObject {
     if ($fc.length) this._$calendar = this._generate_ui($fc);
 
     this.refresh_calendar_date();
+
+    this.wait_something(
+      () =>
+        $('.input-time-end').length > 0 && $('.ui-dialog .save-btn').length > 0,
+    ).then(() => {
+      this._set_validity();
+    });
 
     return $rtn;
   }
@@ -517,6 +571,9 @@ class ResourcesBase extends MelObject {
     const button_save = RcmailDialogButton.ButtonSave({
       click: this.event_on_save,
     });
+
+    button_save.classes += ' save-btn';
+
     const button_cancel = RcmailDialogButton.ButtonCancel({
       click: () => {
         let $parent = this._$calendar;

--- a/plugins/mel_cal_resources/js/lib/resources_functions.js
+++ b/plugins/mel_cal_resources/js/lib/resources_functions.js
@@ -182,6 +182,32 @@ class ResourceBaseFunctions {
       else this._p_resources[i].data.selected = false;
     }
 
+    //Met les dates aux heures de travail
+    const settings = window.cal?.settings || top.cal.settings;
+
+    if (+this.start.format('HH') < settings.work_start) {
+      $('.input-time-start')
+        .val(
+          `${settings.work_start < 9 ? `0${settings.work_start}` : settings.work_start}:00`,
+        )
+        .change();
+    }
+
+    if (+this.end.format('HH') > settings.work_end) {
+      if (+this.start.format('HH') >= settings.work_end) {
+        const start = settings.work_end - 1;
+        $('.input-time-start')
+          .val(`${start < 9 ? `0${start}` : start}:00`)
+          .change();
+      }
+
+      $('.input-time-end')
+        .val(
+          `${settings.work_end < 9 ? `0${settings.work_end}` : settings.work_end}:00`,
+        )
+        .change();
+    }
+
     this._$calendar.fullCalendar('refetchEvents');
   }
 
@@ -368,6 +394,8 @@ class ResourceBaseFunctions {
     this._$calendar.fullCalendar('gotoDate', this.start);
     this._$calendar.fullCalendar('refetchEvents');
 
+    this._set_validity();
+
     this.refresh_calendar_date();
   }
 
@@ -378,7 +406,7 @@ class ResourceBaseFunctions {
    * @param {Event} e Reçu lors du changement de date
    */
   on_date_start_changed(e) {
-    this._functions.on_date_changed($(e.currentTarget), '.input-date-start');
+    this._functions.on_date_changed($(e.currentTarget), '.input-date-start', e);
   }
 
   /**

--- a/plugins/mel_cal_resources/skins/mel_elastic/js_template/resource.js
+++ b/plugins/mel_cal_resources/skins/mel_elastic/js_template/resource.js
@@ -14,8 +14,15 @@ import { EMPTY_STRING } from '../../../../mel_metapage/js/lib/constants/constant
  * @memberof Plugins.MelCalResource.exports.template_resource
  */
 function get_page(page, filters, resource) {
+    const settings = window.cal?.settings || top.cal.settings;
     const date = (resource.start ?? moment().startOf('day'));
     const end_date = (resource.end ?? moment());
+
+    const business_hour = function(time) {
+        if (+time < 9) time = `0${time}`;
+
+        return `${time}:00`;
+    };
 
     page
     .start_update_content({ force_restart: true })
@@ -47,7 +54,7 @@ function get_page(page, filters, resource) {
                         .icon('schedule').end()
                     .end()
                     .input_text({ class:'input-date-start', datepicker: true, value:date.format(DATE_FORMAT), onchange:resource._functions.on_date_start_changed }).css('margin-right', '5px')
-                    .input_time({ class:'input-time-start', value:date.format(DATE_HOUR_FORMAT), onchange:resource._functions.on_time_start_changed }).css('display', resource.all_day ? 'none' : EMPTY_STRING).css('margin-right', '5px')
+                    .input_time({ class:'input-time-start',min: business_hour(settings.work_start), max:business_hour(settings.work_end),value:date.format(DATE_HOUR_FORMAT), onchange:resource._functions.on_time_start_changed }).css('display', resource.all_day ? 'none' : EMPTY_STRING).css('margin-right', '5px')
                 .end()
                 .col_6()
                     .div({ class:'custom-control custom-switch' })
@@ -76,7 +83,7 @@ function get_page(page, filters, resource) {
                         .icon('schedule').css('opacity', 0).end()
                     .end()
                     .input_text({ class:'input-date-end', datepicker: true, value:end_date.format(DATE_FORMAT), onchange:resource._functions.on_date_end_changed }).css('margin-right', '5px')
-                    .input_time({ class:'input-time-end', value:end_date.format(DATE_HOUR_FORMAT), onchange:resource._functions.on_time_end_changed }).css('display', resource.all_day ? 'none' : EMPTY_STRING).css('margin-right', '5px')
+                    .input_time({ class:'input-time-end',min: business_hour(settings.work_start), max:business_hour(settings.work_end), value:end_date.format(DATE_HOUR_FORMAT), onchange:resource._functions.on_time_end_changed }).css('display', resource.all_day ? 'none' : EMPTY_STRING).css('margin-right', '5px')
                 .end()
                 .col_6()
                 .end()


### PR DESCRIPTION
>Pour la réservation de ressources, au lieu d'afficher de minuit a minuit on peut s'appuyer sur les créneaux du calendrier pour ne pas afficher les horaires hors du scope. Actuellement on a un scroll automatiquement mais on peut des fois se retrouver à scroller vers minuit et perdre l'info. Là l'idée serait que les créneaux hors heures ouvrées ne soient pas du tout visible (du genre 00h-08h / 18h-00h) en fonction de la configuration agenda de l'utilisateur

FEAT: MANTIS 0008784