### PR TITLE
fix(metrics): Les metrics envoyés régulièrement envoyaient `undefined`

### DIFF
--- a/plugins/mel_metapage/js/lib/mel_object.js
+++ b/plugins/mel_metapage/js/lib/mel_object.js
@@ -108,6 +108,7 @@ class MelObject {
     /**
      * @type {{task:string}}
      * @package
+     * @deprecated Renverra forcément `undefined`, utilisez plutôt {@link FramesManager.Instance.currentTask}
      */
     this.rc_data = { task: '' };
     Object.defineProperties(this, {

--- a/plugins/mel_metapage/js/lib/metapages_actions/bnum/main_nav_metrics.js
+++ b/plugins/mel_metapage/js/lib/metapages_actions/bnum/main_nav_metrics.js
@@ -1,4 +1,5 @@
 import { BnumLog } from '../../classes/bnum_log.js';
+import { FramesManager } from '../../classes/frame_manager.js';
 import { Look, LookLabel } from '../../classes/metrics.js';
 import { AMetricsModule } from '../ametrics_module.js';
 
@@ -56,7 +57,7 @@ export class MainNavMetrics extends AMetricsModule {
   tasks_corrections(task) {
     switch (task) {
       case 'discussion':
-        task = 'chat';
+        task = 'tchap';
         break;
 
       default:
@@ -75,7 +76,7 @@ export class MainNavMetrics extends AMetricsModule {
   }
 
   async _send_current_task() {
-    const task = this.tasks_corrections(this.rc_data.task);
+    const task = this.tasks_corrections(FramesManager.Instance.currentTask);
 
     if (!current_tasks_to_ignore.includes(task)) {
       BnumLog.info('_send_current_task', 'send current task : ', task);


### PR DESCRIPTION
>Suite à la refonte des frames, les metrics envoyé tout les x temps renvoyaient `task_undefined`.

FIX: MANTIS 0008822