### PR TITLE
feat(rcs): Flex office-mettre le nom de la personne qui réserve plutôt que le libellé "occupé"

### DIFF
--- a/plugins/mel_cal_resources/js/lib/resources_functions.js
+++ b/plugins/mel_cal_resources/js/lib/resources_functions.js
@@ -413,7 +413,7 @@ class ResourceEvent {
      * @type {string}
      * @default 'Occupé'
      */
-    this.title = rcmail.gettext('mel_cal_resources.busy');
+    this.title = slot.creator;
     /**
      * Date de début de l'évènement
      * @type {external:moment}

--- a/plugins/mel_cal_resources/js/lib/resources_functions.js
+++ b/plugins/mel_cal_resources/js/lib/resources_functions.js
@@ -404,16 +404,16 @@ class ResourceBaseFunctions {
 class ResourceEvent {
   /**
    * Constructeur de la classe
-   * @param {Slot} slot Slot qui contient les données
+   * @param {import('../../../mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js').Slot} slot Slot qui contient les données
    * @param {string} email Email qui correspond à l'id
    */
   constructor(slot, email) {
     /**
-     * Titre de l'évènement
+     * Titre de l'évènement, occupé si on ne connaît pas l'organisateur
      * @type {string}
      * @default 'Occupé'
      */
-    this.title = slot.creator;
+    this.title = slot.creator.name || 'Occupé';
     /**
      * Date de début de l'évènement
      * @type {external:moment}

--- a/plugins/mel_cal_resources/js/lib/resources_functions.js
+++ b/plugins/mel_cal_resources/js/lib/resources_functions.js
@@ -3,6 +3,7 @@ import { BnumMessage } from '../../../mel_metapage/js/lib/classes/bnum_message.j
 import { MelEnumerable } from '../../../mel_metapage/js/lib/classes/enum.js';
 import { DATE_TIME_FORMAT } from '../../../mel_metapage/js/lib/constants/constants.dates.js';
 import { EMPTY_STRING } from '../../../mel_metapage/js/lib/constants/constants.js';
+import { MelObject } from '../../../mel_metapage/js/lib/mel_object.js';
 import { FavoriteLoader } from './favorite_loader.js';
 import { ResourcesBase } from './resource_base.js';
 import { HTMLResourceElement } from './webcomponents/HTMLResourceElement.js';
@@ -413,7 +414,11 @@ class ResourceEvent {
      * @type {string}
      * @default 'Occupé'
      */
-    this.title = slot.creator.name || 'Occupé';
+    this.title =
+      (slot.creator.id === MelObject.Empty().get_env('username')
+        ? MelObject.Empty().gettext('me', 'mel_cal_resources')
+        : slot.creator.name) ||
+      MelObject.Empty().gettext('busy', 'mel_cal_resources');
     /**
      * Date de début de l'évènement
      * @type {external:moment}

--- a/plugins/mel_cal_resources/js/lib/resources_functions.js
+++ b/plugins/mel_cal_resources/js/lib/resources_functions.js
@@ -434,5 +434,11 @@ class ResourceEvent {
      * @type {string}
      */
     this.resourceId = email;
+
+    //Diff' entre les autres utilisateurs et l'utilisateur en cours.
+    if (slot.creator.id === MelObject.Empty().get_env('username')) {
+      this.borderColor = 'rouge';
+      this.backgroundColor = 'green';
+    }
   }
 }

--- a/plugins/mel_cal_resources/localization/fr_FR.inc
+++ b/plugins/mel_cal_resources/localization/fr_FR.inc
@@ -15,3 +15,4 @@ $labels['resarcs'] = 'Réserver une ressource';
 $labels['no-resources'] = 'Aucune ressources';
 $labels['busy'] = 'Occupé';
 $labels['automatic-resa-title'] = 'Réservation : %0';
+$labels['me'] = 'Moi';

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js
@@ -455,11 +455,16 @@ export class Slot {
 
   /**
    * Créateur du free-busy
-   * @type {string | false}
+   * @type {Readonly<{id: string | false, name: string | false}>}
    * @readonly
    */
   get creator() {
-    return this.#_creator || false;
+    const splited = (this.#_creator || '/').split('/');
+
+    return {
+      id: splited?.[0] || false,
+      name: splited?.[1] || false,
+    };
   }
 
   /**

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js
@@ -106,7 +106,6 @@ export class FreeBusyGuests {
             _remote: 1,
           },
           success: function (data) {
-            console.log('received', data);
             // find attendee
             var i,
               attendee = null;
@@ -294,7 +293,6 @@ export class Slots {
     for (let index = 0, len = this.slots.length; index < len; ++index) {
       current_slot = this.slots[index];
       next_slot = this.slots[index + 1];
-      console.log('slot', current_slot.creator, next_slot?.creator);
       if (!slot) {
         if (this.#_is_same(current_slot, next_slot)) {
           slot = current_slot;

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js
@@ -106,6 +106,7 @@ export class FreeBusyGuests {
             _remote: 1,
           },
           success: function (data) {
+            console.log('received', data);
             // find attendee
             var i,
               attendee = null;
@@ -256,7 +257,9 @@ export class Slots {
 
     for (let index = 0, len = data.slots.length; index < len; ++index) {
       const slot = data.slots[index];
-      this.slots.push(new Slot(this.start, this.interval, index, slot));
+      this.slots.push(
+        new Slot(this.start, this.interval, index, slot, data.creators[index]),
+      );
     }
   }
 
@@ -291,13 +294,14 @@ export class Slots {
     for (let index = 0, len = this.slots.length; index < len; ++index) {
       current_slot = this.slots[index];
       next_slot = this.slots[index + 1];
+      console.log('slot', current_slot.creator, next_slot?.creator);
       if (!slot) {
-        if (this._is_same(current_slot, next_slot)) {
+        if (this.#_is_same(current_slot, next_slot)) {
           slot = current_slot;
         } else yield current_slot;
       } else {
-        if (!this._is_same(current_slot, next_slot)) {
-          slot = this._extend_slot(slot, current_slot);
+        if (!this.#_is_same(current_slot, next_slot)) {
+          slot = this.#_extend_slot(slot, current_slot);
           yield slot;
           slot = null;
         }
@@ -305,21 +309,37 @@ export class Slots {
     }
   }
 
-  _is_same(slot, next_slot) {
+  /**
+   * Vérifie si un slot est identique ou non
+   * @param {Slot} slot
+   * @param {Slot} next_slot
+   * @returns {boolean}
+   * @private
+   */
+  #_is_same(slot, next_slot) {
     return (
       next_slot &&
       slot.end.format(DATE_TIME_FORMAT) ===
         next_slot.start.format(DATE_TIME_FORMAT) &&
-      slot.state === next_slot.state
+      slot.state === next_slot.state &&
+      slot.creator === next_slot.creator
     );
   }
 
-  _extend_slot(slot, next_slot) {
+  /**
+   * Vérifie si un slot est identique ou non
+   * @param {Slot} slot
+   * @param {Slot} next_slot
+   * @returns {boolean}
+   * @private
+   */
+  #_extend_slot(slot, next_slot) {
     return new Slot(
       slot.start,
       moment.duration(next_slot.end.diff(slot.start)).as('minutes'),
       0,
       slot.state,
+      slot.creator || next_slot.creator,
     );
   }
 
@@ -353,14 +373,17 @@ export class Slots {
  * @classdesc Représentation d'un créneau horraire avec l'information de sa disponibilitée ou non
  */
 export class Slot {
+  #_creator;
   /**
    *
    * @param {string | external:moment | date | number} start Date de début
    * @param {number} interval Interval entre chaque créneau
    * @param {number} index Index du créneau
    * @param {string} state Etat du créneau
+   * @param {string} creator Possesseur du free-busy
    */
-  constructor(start, interval, index, state) {
+  constructor(start, interval, index, state, creator) {
+    this.#_creator = creator;
     /**
      * Date de début du créneaux
      * @type {external:moment}
@@ -428,6 +451,15 @@ export class Slot {
         this.start.format('d') === '0' ||
         this.start.format('d') === '6',
     });
+  }
+
+  /**
+   * Créateur du free-busy
+   * @type {string | false}
+   * @readonly
+   */
+  get creator() {
+    return this.#_creator || false;
   }
 
   /**

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js
@@ -320,7 +320,7 @@ export class Slots {
       slot.end.format(DATE_TIME_FORMAT) ===
         next_slot.start.format(DATE_TIME_FORMAT) &&
       slot.state === next_slot.state &&
-      slot.creator === next_slot.creator
+      slot.creator.id === next_slot.creator.id
     );
   }
 
@@ -457,12 +457,18 @@ export class Slot {
    * @readonly
    */
   get creator() {
-    const splited = (this.#_creator || '/').split('/');
+    let freeBusyCreator;
+    if (this.#_creator?.id && this.#_creator?.name) freeBusyCreator = this.#_creator;
+    else {
+      const splited = (this.#_creator || '/').split('/');
 
-    return {
-      id: splited?.[0] || false,
-      name: splited?.[1] || false,
-    };
+      freeBusyCreator = {
+        id: splited?.[0] || false,
+        name: splited?.[1] || false,
+      };
+    }
+
+    return freeBusyCreator;
   }
 
   /**

--- a/plugins/mel_metapage/js/lib/calendar/free_busy_loader.js
+++ b/plugins/mel_metapage/js/lib/calendar/free_busy_loader.js
@@ -78,7 +78,7 @@ class FreeBusyClassLoader extends MelObject {
             method: 'GET',
             on_success: (d) => {
               if (typeof d === 'string') d = JSON.parse(d);
-              console.log('freebusy', d);
+
               ok(new Slots(d));
             },
           });

--- a/plugins/mel_metapage/js/lib/calendar/free_busy_loader.js
+++ b/plugins/mel_metapage/js/lib/calendar/free_busy_loader.js
@@ -78,6 +78,7 @@ class FreeBusyClassLoader extends MelObject {
             method: 'GET',
             on_success: (d) => {
               if (typeof d === 'string') d = JSON.parse(d);
+              console.log('freebusy', d);
               ok(new Slots(d));
             },
           });


### PR DESCRIPTION
>Actuellement, lors d'une réservation d'une ressource , il y a le statut "occupé" qui s'affiche au niveau du créneau choisi par l'agent.

>Ce qui pourrait être bien serait de mettre le nom de la personne qui réserve la ressource à la place du libellé "occupé". 

FEAT: MANTIS 0008587