### PR TITLE
Feat(Forum) : Mise en place des notifications pour les commentaires et les réponses

### DIFF
--- a/plugins/mel_forum/js/lib/comments.js
+++ b/plugins/mel_forum/js/lib/comments.js
@@ -402,6 +402,8 @@ class PostComment {
                     _post_id: this.post_id, // L'ID du post
                     _content: replyContent, // Le contenu de la réponse
                     _parent: this.parent, // ID du commentaire parent
+                    _workspace_uid: rcmail.env.workspace_uid,
+                    _post_uid: rcmail.env.post_uid,
                 },
             });
 

--- a/plugins/mel_forum/js/lib/manager.js
+++ b/plugins/mel_forum/js/lib/manager.js
@@ -145,8 +145,10 @@ export class Manager extends MelObject {
         task: 'forum',
         action: 'create_comment',
         params: {
+          _post_uid: this.post_uid,
           _post_id: this.post_id,
           _content: content,
+          _workspace_uid: this.get_env('workspace_uid'),
         },
       });
 

--- a/plugins/mel_forum/localization/fr_FR.inc
+++ b/plugins/mel_forum/localization/fr_FR.inc
@@ -252,7 +252,17 @@ $labels['a_post_has_been_published'] = '📰 Un article a été publié dans vot
 
 #region NOTIFICATION
 
-$labels['post_published_message'] = 'Découvrez le nouvel article intitulé : "%s" en cliquant sur le lien ci-dessous.';
+$labels['notification_comment_message'] = 'Accédez au commentaire de : "%s" en cliquant sur le lien ci-dessous.';
+$labels['notification_comment_title'] = '%s a commenté votre article : "%s".';
+$labels['notification_response_message_for_author'] = 'Accédez à la réponse de %s au commentaire de %s en cliquant sur le lien ci-dessous.';
+$labels['notification_response_message_for_commenter'] = 'Accédez à la réponse de %s en cliquant sur le lien ci-dessous.';
+$labels['notification_response_title_for_author'] = '%s a répondu au commentaire de %s concernant votre article "%s".';
+$labels['notification_response_title_for_commenter'] = '%s a répondu à votre commentaire concernant l\'article "%s".';
 $labels['notification_title'] = '%s a publié un nouvel article dans l\'espace : %s';
+$labels['post_published_message'] = 'Découvrez le nouvel article intitulé : "%s" en cliquant sur le lien ci-dessous.';
 $labels['read_article'] = 'Lire l\'article';
 $labels['read_article_title'] = 'Cliquez pour lire l\'article';
+$labels['read_comment'] = 'Lire le commentaire';
+$labels['read_comment_title'] = 'Cliquez pour lire le commentaire';
+$labels['read_response'] = 'Lire la réponse';
+$labels['read_response_title'] = 'Cliquez pour lire la réponse';

--- a/plugins/mel_forum/mel_forum.php
+++ b/plugins/mel_forum/mel_forum.php
@@ -41,6 +41,7 @@ class mel_forum extends bnum_plugin
     {
         // $this->rc()->output->send('mel_forum.forum');
 
+
         // Chargement de la conf
         // $this->load_config();
         // Gestion des différentes langues
@@ -54,56 +55,52 @@ class mel_forum extends bnum_plugin
         $this->register_task('forum');
 
         if ($this->rc()->task === "forum") {
-            $workspace_uid = $this->get_input('_workspace_uid', rcube_utils::INPUT_GET);
-            if (driver_mel::gi()->getUser()->isWorkspaceMember($workspace_uid)) {
-            
-                // Penser à modifier avec index au lieu de post pour afficher la page d'accueil
-                $this->register_action('index', [$this, 'index']);
-                //Affichage de la page d'un article
-                $this->register_action('post', [$this, 'post']);
-                // Affichage de la page qui permet de créer un article
-                $this->register_action('create_or_edit_post', [$this, 'create_or_edit_post']);
-                // Créer/Modifier un article
-                $this->register_action('add_post', array($this, 'add_post'));
-                //supprimer un article
-                $this->register_action('delete_post', array($this, 'delete_post'));
-                // Ajouter un commentaire ou une réponse
-                $this->register_action('create_comment', array($this, 'create_comment'));
-                // Modifier un commentaire ou une réponse
-                $this->register_action('update_comment', array($this, 'update_comment'));
-                // Supprimer un commentaire ou une réponse
-                $this->register_action('delete_comment', array($this, 'delete_comment'));
-                // Liker un commentaire ou une réponse
-                $this->register_action('like_comment', array($this, 'like_comment'));
-                //Lister les comments d'un Post
-                $this->register_action('get_all_comments_bypost', [$this, 'get_all_comments_bypost']);
-                //Gère la modification/création d'un post
-                $this->register_action('send_post', array($this, 'send_post'));
-                // Import une image sur le serveur
-                $this->register_action('upload_image', array($this, 'upload_image'));
-                // affiche une image chargé sur le serveur
-                $this->register_action('load_image', array($this, 'load_image'));
-                // ajoute un article aux favoris de l'utilisateur courant
-                $this->register_action('manage_favorite', array($this, 'manage_favorite'));
-                // récupérer des posts au format Json
-                $this->register_action('get_posts_data', array($this, 'get_posts_data'));
-                // gestion des réaction aux posts
-                $this->register_action('manage_reaction', array($this, 'manage_reaction'));
-                // Affichage des nouveaux posts
-                $this->register_action('new_posts', array($this, 'new_posts'));
-                //Affichage du post à la une
-                $this->register_action('front_page_post', array($this, 'front_page_post'));
-                //Reload du post à la une
-                $this->register_action('refresh_front_page_post', array($this, 'refresh_front_page_post'));
-                //Épingler un post
-                $this->register_action('pin_post', array($this, 'pin_post'));
-                // Conversion d'un article en Markdown
-                $this->register_action('convert_post_in_markdown', [$this, 'convert_post_in_markdown']);
-                $this->register_action('download_article', [$this, 'download_article']);
-                $this->register_action('create_zip_with_md_and_images', [$this, 'create_zip_with_md_and_images']);
-            } else {
-                $this->_display_error_page();
-            }
+
+            // Penser à modifier avec index au lieu de post pour afficher la page d'accueil
+            $this->register_action('index', [$this, 'index']);
+            //Affichage de la page d'un article
+            $this->register_action('post', [$this, 'post']);
+            // Affichage de la page qui permet de créer un article
+            $this->register_action('create_or_edit_post', [$this, 'create_or_edit_post']);
+            // Créer/Modifier un article
+            $this->register_action('add_post', array($this, 'add_post'));
+            //supprimer un article
+            $this->register_action('delete_post', array($this, 'delete_post'));
+            // Ajouter un commentaire ou une réponse
+            $this->register_action('create_comment', array($this, 'create_comment'));
+            // Modifier un commentaire ou une réponse
+            $this->register_action('update_comment', array($this, 'update_comment'));
+            // Supprimer un commentaire ou une réponse
+            $this->register_action('delete_comment', array($this, 'delete_comment'));
+            // Liker un commentaire ou une réponse
+            $this->register_action('like_comment', array($this, 'like_comment'));
+            //Lister les comments d'un Post
+            $this->register_action('get_all_comments_bypost', [$this, 'get_all_comments_bypost']);
+            //Gère la modification/création d'un post
+            $this->register_action('send_post', array($this, 'send_post'));
+            // Import une image sur le serveur
+            $this->register_action('upload_image', array($this, 'upload_image'));
+            // affiche une image chargé sur le serveur
+            $this->register_action('load_image', array($this, 'load_image'));
+            // ajoute un article aux favoris de l'utilisateur courant
+            $this->register_action('manage_favorite', array($this, 'manage_favorite'));
+            // récupérer des posts au format Json
+            $this->register_action('get_posts_data', array($this, 'get_posts_data'));
+            // gestion des réaction aux posts
+            $this->register_action('manage_reaction', array($this, 'manage_reaction'));
+            // Affichage des nouveaux posts
+            $this->register_action('new_posts', array($this, 'new_posts'));
+            //Affichage du post à la une
+            $this->register_action('front_page_post', array($this, 'front_page_post'));
+            //Reload du post à la une
+            $this->register_action('refresh_front_page_post', array($this, 'refresh_front_page_post'));
+            //Épingler un post
+            $this->register_action('pin_post', array($this, 'pin_post'));
+            // Conversion d'un article en Markdown
+            $this->register_action('convert_post_in_markdown', [$this, 'convert_post_in_markdown']);
+            $this->register_action('download_article', [$this, 'download_article']);
+
+            $this->register_action('create_zip_with_md_and_images', [$this, 'create_zip_with_md_and_images']);
         } else if ($this->get_current_task() === 'workspace') {
             $this->add_hook('workspace.services.set', [$this, 'workspace_services_set']);
             $this->add_hook('wsp.show', [$this, 'wsp_show']);
@@ -126,12 +123,16 @@ class mel_forum extends bnum_plugin
     public function index()
     {
         $workspace_uid = $this->get_input('_workspace_uid', rcube_utils::INPUT_GET);
-        $this->include_web_component()->Avatar();
-        $this->load_script_module('forum');
-        $this->_show_posts();
-        $this->rc()->output->set_env('workspace_uid', $workspace_uid);
-        $this->rc()->output->add_handlers(array('post_search' => array($this, '_show_search')));
-        $this->rc()->output->send('mel_forum.forum');
+        if (driver_mel::gi()->getUser()->isWorkspaceMember($workspace_uid)) {
+            $this->include_web_component()->Avatar();
+            $this->load_script_module('forum');
+            $this->_show_posts();
+            $this->rc()->output->set_env('workspace_uid', $workspace_uid);
+            $this->rc()->output->add_handlers(array('post_search' => array($this, '_show_search')));
+            $this->rc()->output->send('mel_forum.forum');
+        } else {
+            $this->_display_error_page();
+        }
     }
 
     // Fonctions nécessaires à l'affichage d'un article
@@ -1065,6 +1066,8 @@ class mel_forum extends bnum_plugin
         $content = $this->get_input('_content', rcube_utils::INPUT_POST);
         $post = $this->get_input('_post_id', rcube_utils::INPUT_POST);
         $parent = $this->get_input('_parent', rcube_utils::INPUT_POST, true);
+        $workspace_uid = $this->get_input('_workspace_uid', rcube_utils::INPUT_POST);
+        $post_uid = $this->get_input('_post_uid', rcube_utils::INPUT_POST);
 
         // Validation des données
         if (empty($content)) {
@@ -1101,6 +1104,9 @@ class mel_forum extends bnum_plugin
                     'message' => $this->gettext("comment_creation_failed", "mel_forum")
                 ]);
             }
+            // Appel de la fonction de notification d'ajout d'un commentaire ou d'une réponse
+            $this->notify_comment($workspace_uid, $parent, $post_uid);
+
         } else {
             // Gestion d'une erreur de sauvegarde
             $this->sendEncodedExit([
@@ -1118,7 +1124,9 @@ class mel_forum extends bnum_plugin
             'creator' => $comment->creator,
             'post' => $comment->post,
             'parent' => !empty($comment->parent) ? $comment->parent : null,
-            'user_name' => $user->name
+            'user_name' => $user->name,
+            'workspace_uid' => $workspace_uid,
+            'post_uid' => $post_uid,
         ];
 
         // Réponse JSON avec succès
@@ -2762,6 +2770,126 @@ class mel_forum extends bnum_plugin
                             $user->user
                         );
                     }
+                }
+            }
+        }
+    }
+
+    /**
+     * Envoie une notification lors de l'ajout d'un commentaire ou d'une réponse à un commentaire.
+     *
+     * Cette fonction notifie les utilisateurs concernés lorsqu'un nouveau commentaire est ajouté à un post
+     * ou lorsqu'une réponse est faite à un commentaire existant. Les notifications sont envoyées au créateur
+     * du post et en cas de réponse, également au créateur du commentaire parent.
+     *
+     * @param string $workspace_uid L'identifiant unique de l'espace de travail.
+     * @param string|null $parent_id L'identifiant du commentaire parent (null si c'est un nouveau commentaire).
+     * @param string $post_uid L'identifiant unique du post associé au commentaire.
+     *
+     * @return void
+     */
+    public function notify_comment($workspace_uid, $parent_id, $post_uid) {
+        if (class_exists("mel_notification")) {
+            $post_id = rcube_utils::get_input_value('_post_id', rcube_utils::INPUT_POST);
+    
+            if ($workspace_uid !== null && $post_id !== null) {
+                $workspace = mel_workspace::Workspace($workspace_uid);
+                $current_user = driver_mel::gi()->getUser();
+    
+                // Récupérer les infos du post
+                $post = $this->_get_post($post_uid);
+                $post_title = $post->title;
+                $post_creator = $post->creator; // UID du créateur du post
+    
+                // Récupération du créateur du commentaire parent
+                $parent_creator = null;
+                if (!empty($parent_id)) {  // Vérifie si un parent existe
+                    $parent_comment = new LibMelanie\Api\Defaut\Posts\Comment();
+                    $parent_comment->id = $parent_id;
+                    $parent_comments = $parent_comment->getList();
+    
+                    if (count($parent_comments)) {  
+                        $parent_comment = array_pop($parent_comments);
+                        $parent_creator = $parent_comment->user_uid; // UID du créateur du commentaire parent
+                    }
+                }
+    
+                // Initialisation de la liste des utilisateurs à notifier
+                $users_to_notify = [];
+    
+                if (empty($parent_id)) {
+                    // *** NOUVEAU COMMENTAIRE sur l'article ***
+                    $notification_comment_title = sprintf(
+                        $this->gettext("mel_forum.notification_comment_title"),
+                        $current_user->name,
+                        $post_title
+                    );
+    
+                    $notification_comment_message = sprintf(
+                        $this->gettext("mel_forum.notification_comment_message"),
+                        $current_user->name
+                    );
+    
+                    // Ajouter le créateur du post à la liste des notifications (sauf si c'est lui qui commente)
+                    if ($post_creator !== $current_user->uid) {
+                        $users_to_notify[$post_creator] = [
+                            'title' => $notification_comment_title,
+                            'message' => $notification_comment_message
+                        ];
+                    }
+                } else {
+                    // *** RÉPONSE à un commentaire existant ***
+                    if (!empty($parent_creator)) {
+                        // Notification pour le créateur de l'article
+                        if ($post_creator !== $current_user->uid) {
+                            $users_to_notify[$post_creator] = [
+                                'title' => sprintf(
+                                    $this->gettext("mel_forum.notification_response_title_for_author"),
+                                    $current_user->name,
+                                    $parent_creator,
+                                    $post_title
+                                ),
+                                'message' => sprintf(
+                                    $this->gettext("mel_forum.notification_response_message_for_author"),
+                                    $current_user->name,
+                                    $parent_creator
+                                )
+                            ];
+                        }
+    
+                        // Notification pour le créateur du commentaire
+                        if ($parent_creator !== $current_user->uid) {
+                            $users_to_notify[$parent_creator] = [
+                                'title' => sprintf(
+                                    $this->gettext("mel_forum.notification_response_title_for_commenter"),
+                                    $current_user->name,
+                                    $post_title
+                                ),
+                                'message' => sprintf(
+                                    $this->gettext("mel_forum.notification_response_message_for_commenter"),
+                                    $current_user->name
+                                )
+                            ];
+                        }
+                    }
+                }
+    
+                // Envoyer les notifications uniquement aux utilisateurs concernés
+                foreach ($users_to_notify as $user_uid => $notification) {
+                    mel_notification::notify(
+                        'workspace',
+                        $notification['title'],
+                        $notification['message'],
+                        [
+                            [
+                                'href' => "./?_task=forum&_action=post&_uid=" . $post_uid . "&_workspace_uid=" . $workspace_uid . "#comment-section",
+                                'text' => $this->gettext("mel_forum.read_response"),
+                                'title' => $this->gettext("mel_forum.read_response_title"),
+                                'command' => "event.click"
+                            ]
+                        ],
+                        $user_uid
+                    );
                 }
             }
         }


### PR DESCRIPTION
Lorsqu'un commentaire est ajouté, la notification concerne uniquement le créateur du post.
Lorsqu'une réponse est ajoutée, la notification concerne le créateur du post et le créateur du commentaire.

Si la discussion comprend plusieurs niveau de réponse (ex: une réponse à une réponse à une réponse à une réponse ...), seul l'auteur du dernier commentaire et le créateur du post sont notifiés.