### PR TITLE
0008867 - La recherche de prochaines disponibilités communes devrait se baser sur le choix de la période

### DIFF
--- a/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.free_busy.js
@@ -68,7 +68,7 @@ export class FreeBusyGuests {
   async load_freebusy_data(event) {
     if (!FreeBusyGuests.can) return [];
 
-    const interval = this.interval;
+    const interval = event.interval || this.interval;
     const event_attendees = event.attendees;
     const date2servertime = cal.date2ISO8601;
     const fix_date = FreeBusyGuests.FixDate;
@@ -458,7 +458,8 @@ export class Slot {
    */
   get creator() {
     let freeBusyCreator;
-    if (this.#_creator?.id && this.#_creator?.name) freeBusyCreator = this.#_creator;
+    if (this.#_creator?.id && this.#_creator?.name)
+      freeBusyCreator = this.#_creator;
     else {
       const splited = (this.#_creator || '/').split('/');
 

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.js
@@ -1104,6 +1104,7 @@ export class GuestsPart extends FakePart {
             start,
             end,
             attendees,
+            interval: (end - start) / 1000 / 60,
           }),
       );
 
@@ -1119,6 +1120,7 @@ export class GuestsPart extends FakePart {
       }
 
       const slots = await promise;
+
       promise = null;
       let $find_next = MelHtml.start
         .button({
@@ -1140,6 +1142,11 @@ export class GuestsPart extends FakePart {
           slot
             .generate(timePart)
             .generate()
+            .addClass(
+              moment(slot.start).format() === timePart.date_start.format()
+                ? 'current-date btn-success'
+                : 'not-current-date',
+            )
             .appendTo(
               $('<div>')
                 .addClass('col-6 col-md-3')


### PR DESCRIPTION
>Si je crée un événement de 2h en glisser/lacher puis que j'ajoute des participants, il faudrait que la recherche de la prochaine dispo commune se base sur 2h et pas 30min.
>Idem si j'ajoute des participants, puis que je change la valeur de début et/ou fin dans Choix de la période, la prochaine dispo devrait s'actualiser avec la nouvelle durée d'événement.