### PR TITLE
recette : Dans certains cas, le changement de frame ne se faisait pas.

### DIFF
--- a/plugins/mel_forum/js/lib/workspace.js
+++ b/plugins/mel_forum/js/lib/workspace.js
@@ -160,7 +160,7 @@ export class ModuleForum extends WorkspaceObject {
             jquery: false,
           }).contentWindow.location.href.includes(this.workspace.uid))
       ) {
-        return { _workspace_uid: this.workspace.uid };
+        return { _workspace_uid: this.workspace.uid, askedTask: args.task };
       }
     }, 'forum');
   }

--- a/plugins/mel_workspace/js/lib/program/actions/page.workspace.js
+++ b/plugins/mel_workspace/js/lib/program/actions/page.workspace.js
@@ -71,6 +71,7 @@ export class WorkspacePage extends WorkspaceObject {
       if (task === 'tasks' && !FramesManager.Instance.has_frame('tasks')) {
         return {
           source: this.workspace.uid,
+          askedTask: 'tasks',
         };
       } else if (task === 'tasks') {
         FramesManager.Instance.get_frame('tasks', {


### PR DESCRIPTION
Le "OnBeforeSwitch" étant un trigger avec plusieurs données de retours, ça ne fonctionnait pas correctement et aucun `askedTask` était retourné, ce qui fait qu'on ne prennait pas en compte les nouvelles configurations pour le changement de frame.

TODO: Améliorer le système