### PR TITLE
0008847 - Duplication / copier sans participant d'evt privé affiche le cadenas en ouvert et donc en public

### DIFF
--- a/plugins/mel_metapage/js/lib/calendar/event/event_view.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/event_view.js
@@ -330,12 +330,8 @@ class EventParts {
       inputs.select_calendar_owner.parent().find('span'),
       ev?.calendar_blocked ?? false,
     );
-    this.status.onUpdate(ev.status ?? '');
-    this.sensitivity.onUpdate(
-      !ev?.id
-        ? SensitivityPart.STATES.public
-        : ev?.sensitivity ?? SensitivityPart.STATES.public,
-    );
+    this.status.onUpdate(ev.status ?? EMPTY_STRING);
+    this.sensitivity.onUpdate(ev?.sensitivity ?? SensitivityPart.STATES.public);
     this.alarm.init(ev);
     this.category.init(ev);
     this.date.init(ev);


### PR DESCRIPTION
>La duplication ou la reprise de l'evt privé sans participant remet systématiquement la confidentialité en public