### PR TITLE
retour recette 0008724: Impossible d'inviter une personne en @ars.sante.fr

### DIFF
--- a/plugins/mel/lib/drivers/mtes/mtes.php
+++ b/plugins/mel/lib/drivers/mtes/mtes.php
@@ -97,6 +97,7 @@ class mtes_driver_mel extends mce_driver_mel
     'lastname'          => '%%lastname%%',
     'firstname'         => '%%firstname%%',
     'uid'               => '%%uid%%',
+    'email_extern'      => '%%email%%',
   ];
 
   /**


### PR DESCRIPTION
Ajouter l'email_extern dans un utilisateur externe, sinon il ne sera pas retrouvé dans la recherche (suite au nouveau format)