### PR TITLE
recette - 0008901 - F5 ne fonctionnait pas toujours sur un module d'un espace

### DIFF
--- a/plugins/mel_workspace/js/lib/program/actions/page.workspace.js
+++ b/plugins/mel_workspace/js/lib/program/actions/page.workspace.js
@@ -182,12 +182,21 @@ export class WorkspacePage extends WorkspaceObject {
     );
 
     if (this.get_env('start_page')) {
-      NavBarManager.WaitLoading().then(() => {
-        NavBarManager.currentNavBar.select(this.get_env('start_page'), {
-          background: false,
-        });
-      });
+      //Si le document est chargé, on l'applique
+      if (document.readyState === 'complete') this._setStartupPage();
+      //Sinon, on attend que toute les dépendances soient chargées
+      else window.addEventListener('load', this._setStartupPage.bind(this));
     }
+  }
+
+  /**
+   * Set the startup page based on the environment variable.
+   * @returns {Promise<void>}
+   * @private
+   */
+  async _setStartupPage() {
+    await NavBarManager.WaitLoading(),
+      this.switch_workspace_page(this.get_env('start_page'));
   }
 
   #_get_row(number = 0) {


### PR DESCRIPTION
>Parfois, il y avait juste un message d'erreur.
>Cause : Tout les éléments n'étaient pas complètement chargé
