### PR TITLE
recette - 0008898 - certaines fonctionnalités doivent être caché aux externes

### DIFF
--- a/plugins/mel_workspace/js/lib/program/actions/page.workspace.js
+++ b/plugins/mel_workspace/js/lib/program/actions/page.workspace.js
@@ -108,21 +108,28 @@ export class WorkspacePage extends WorkspaceObject {
           break;
 
         case 'send':
-          if (this.workspace.users.emails.length >= 300) {
-            if (
-              !confirm(
-                "Attention, la limite d'envoi est de 300 destinataires, vous pourrez envoyer un mail seulement aux 300 premiers membres.",
-              )
+        if (this.workspace.users.emails.length >= 300) {
+          if (
+            !confirm(
+              "Attention, la limite d'envoi est de 300 destinataires, vous pourrez envoyer un mail seulement aux 300 premiers membres.",
             )
-              return;
-          }
+          )
+            return;
+        }
 
-          this.open_compose_step({
-            to: MelEnumerable.from(this.workspace.users.emails)
-              .where((x) => x !== MelCurrentUser.main_email)
-              .take(300)
-              .join(','),
-          });
+          const mails = MelEnumerable.from(this.workspace.users.emails)
+          .where((x) => x !== MelCurrentUser.main_email)
+          .take(300)
+          .join(',');
+
+          if (this.workspace.users.get(this.get_env('current_user').email).external) {
+            window.open(`mailto:${mails}`, '_blank');
+          }
+          else {
+            this.open_compose_step({
+              to: mails,
+            });
+          }
           break;
 
         case 'leave':

--- a/plugins/mel_workspace/mel_workspace.php
+++ b/plugins/mel_workspace/mel_workspace.php
@@ -215,11 +215,15 @@ class mel_workspace extends bnum_plugin
             $plugin ??= [];
     
             $this->workspacePageLayout = $plugin['layout'] ?? new WorkspacePageLayout();
+
+            if (!$this->get_user()->is_external) {
+                $this->workspacePageLayout->fourthRow()->append(4, $this->workspacePageLayout->htmlModuleBlock(['id' => 'module-agenda','data-title' => 'Agenda de l\'espace', 'data-button' => 'calendar', 'data-button-text' => 'Créer', 'data-button-icon' => 'add_circle', 'data-button-ignore' => 'default-actions', 'data-button-type' => 'primary'])); 
+                $this->workspacePageLayout->setNavBarSetting('mel_metapage.calendar', 'calendar_month', true, 1);
+                $this->include_module_program('agenda.js', 'Parts');
+            }
     
             $this->workspacePageLayout->fourthRow()->append(8, $this->workspacePageLayout->htmlModuleBlock(['id' => 'module-planning','data-title' => 'Planning des membres']));
-            $this->workspacePageLayout->fourthRow()->append(4, $this->workspacePageLayout->htmlModuleBlock(['id' => 'module-agenda','data-title' => 'Agenda de l\'espace', 'data-button' => 'calendar', 'data-button-text' => 'Créer', 'data-button-icon' => 'add_circle', 'data-button-ignore' => 'default-actions', 'data-button-type' => 'primary']));
             $this->workspacePageLayout->setNavBarSetting('home', 'home', false, 0);
-            $this->workspacePageLayout->setNavBarSetting('mel_metapage.calendar', 'calendar_month', true, 1);
             $this->workspacePageLayout->setNavBarSetting('mel_workspace.planning', 'calendar_view_week', true, 1);
     
             if ($workspace->objects()->has(self::KEY_TASK)) $this->workspacePageLayout->setNavBarSetting('tasks', 'check_box', false, 6);
@@ -246,7 +250,6 @@ class mel_workspace extends bnum_plugin
     
             $this->include_css('workspace.css');
             self::IncludeWorkspaceModuleComponent();
-            $this->include_module_program('agenda.js', 'Parts');
             $this->include_module_program('planning.js', 'Parts');
             $this->load_script_module('page.workspace.js', '/js/lib/program/actions/');
             $this->include_script('js/params.js');


### PR DESCRIPTION
Dans le cas où l'invité est un externe >>Dans l'edt la logique est qu'il n'a pas accès à l'agenda ni à la messagerie
Page d'accueil:
Faire en sorte que le bouton écrire aux invité soit inactif et qu'il n'ouvre pas une nouvelle fenêtre de rédaction de mail ou bien que ça le redirige vers sa messagerie par défaut

"Le panneau de gauche affiche Agenda >> Le clic redirige vers la liste des EDT dont il a accès -->Résultat attendu: soit cacher le module soit faire en sorte que le clic lui indique dans une pop up vous n'êtes pas autorisé à accéder à ce module
La séparation du planning et agenda est bien, mais pour la partie affichée de l'agenda le bouton Créer induit en erreur (la modale création de l'evt s'affiche) et au moment de rattacher à l'edt ou enregistrer ça mouline
Résultat attendu: le bouton ne soit pas visible ou bien faire comme pour le panneau de gauche pop up"