### PR TITLE
0008906 - :bug: Faire en sorte que le titre affiché pour tous les modules reprend bien espace de travail

### DIFF
--- a/plugins/mel_workspace/js/lib/program/actions/page.workspace.js
+++ b/plugins/mel_workspace/js/lib/program/actions/page.workspace.js
@@ -180,6 +180,15 @@ export class WorkspacePage extends WorkspaceObject {
       },
     );
 
+    FramesManager.Helper.window_object.UpdateDocumentTitle(
+      this.getLocalization('page_title', {
+        plugin: 'mel_workspace',
+        variables: {
+          name: this.workspace.title,
+        },
+      }),
+    );
+
     if (this.get_env('start_page')) {
       window.addEventListener('load', () => {
         NavBarManager.WaitLoading().then(() => {

--- a/plugins/mel_workspace/js/lib/program/navbar.generator.js
+++ b/plugins/mel_workspace/js/lib/program/navbar.generator.js
@@ -314,6 +314,15 @@ export class NavBarManager {
         });
         break;
     }
+
+    const useTopContext = true;
+    FramesManager.Helper.window_object.UpdateDocumentTitle(
+      MelObject.Empty().getLocalization('page_title', {
+        plugin: 'mel_workspace',
+        variables: { name: workspace.title },
+      }),
+      useTopContext,
+    );
   }
 
   static Kill(uid) {

--- a/plugins/mel_workspace/localization/workspace/fr_FR.inc
+++ b/plugins/mel_workspace/localization/workspace/fr_FR.inc
@@ -13,3 +13,4 @@ $labels['validation_join_public'] = 'Cet espace est public, cliquez sur "Ok" pou
 $labels['no_public_error'] = 'Cet espace n\'est pas publique, veuillez contactez un utilisateur pour vous ajouter. Redirection vers la liste des espaces....';
 $labels['no_in_addressbook'] = 'Les personnes ajoutées ne font pas partie de l\'annuaire... Elles ne sont donc pas ajoutées à l\'espace';
 $labels['no_event_in_agenda'] = 'Pas d\'évènement dans les 7 prochains jours !';
+$labels['page_title'] = 'Espace de travail "$name"';

--- a/plugins/mel_workspace/mel_workspace.php
+++ b/plugins/mel_workspace/mel_workspace.php
@@ -323,7 +323,7 @@ class mel_workspace extends bnum_plugin
         }
 
         $this->ignore_footer();
-
+        $this->rc()->output->set_pagetitle($this->gettext(['name' => 'page_title', 'name' => $workspace->title()]));
         $this->rc()->output->send('mel_workspace.workspace');
     }
 


### PR DESCRIPTION
Affiche le bon titre sur l'onglet : `Espace de travail : "$name"` au lieu de juste "Espace de travail" ou le nom du module.
