### PR TITLE
0008915 - :bug: Corrections d'élements pas encore utilisé

### DIFF
--- a/plugins/mel_metapage/js/lib/base_mel_object.js
+++ b/plugins/mel_metapage/js/lib/base_mel_object.js
@@ -39,7 +39,7 @@ export default class ABaseMelObject {
    */
   listen(key, callback, { callbackKey = null, topRcmail = false } = {}) {
     if (callbackKey)
-      this.rcmail(topRcmail).add_handler_ex(key, callbackKey, callback);
+      this.rcmail(topRcmail).add_event_listener_ex(key, callbackKey, callback);
     else this.rcmail(topRcmail).addEventListener(key, callback);
 
     return this;

--- a/plugins/mel_metapage/js/lib/classes/frame_manager.js
+++ b/plugins/mel_metapage/js/lib/classes/frame_manager.js
@@ -1199,7 +1199,13 @@ class Window {
       caller: this,
     }) ?? { stop: false };
 
-    if (plugin.stop) return this;
+    if (Array.isArray(plugin)) {
+      for (const callbackResult of plugin) {
+        if (callbackResult.stop) {
+          return this;
+        }
+      }
+    } else if (plugin.stop) return this;
 
     const url = this.get_frame()[0].contentWindow.location.href;
     if (!url) this.get_frame()[0].contentWindow.location.reload();


### PR DESCRIPTION
La fonction refresh pouvait ne pas fonctionner correctement : 
rcmail.trigger peut renvoyer un tableau et ça n'était pas pris en compte par la fonction `refresh`. Ce qui pouvait entrainer des bugs cars la propriétée `stop` n'était donc parfois pas lue.

La fonction `listen` ne fonctionnait pas correctement :
Lorsqu'un `callback_key` lui était passé, la fonction appelé n'avait pas le bon nom.