### PR TITLE
[HOTFIX] 0008932: impossible de télécharger un article

### DIFF
--- a/plugins/mel_forum/js/lib/manager.js
+++ b/plugins/mel_forum/js/lib/manager.js
@@ -689,6 +689,7 @@ export class Manager extends MelObject {
                 params: {
                   _uid: uid,
                   _format: selectedFormat,
+                  _workspace_uid: this.get_env('workspace_uid'),
                 },
                 removeIsFromIframe: true,
               });


### PR DESCRIPTION
lors du téléchargement d'un article -> page d'erreur car il manquait le workspace_uid dans l'url 