### PR TITLE
0008342 - :bug: Erreur si l'on clique deux fois sur enregistrer dans le gestionnaire d'absence

### DIFF
--- a/plugins/mel_moncompte/moncompte/Gestionnaireabsence.php
+++ b/plugins/mel_moncompte/moncompte/Gestionnaireabsence.php
@@ -478,8 +478,12 @@ class Gestionnaireabsence extends Moncompteobject
       } else {
         // Erreur
         $err = \LibMelanie\Ldap\Ldap::GetInstance(\LibMelanie\Config\Ldap::$MASTER_LDAP)->getError();
-        rcmail::get_instance()->output->show_message(rcmail::get_instance()->gettext('mel_moncompte.absence_nok') . ' : ' . $err, 'error');
-        return false;
+        if ($err === '0: Success') {
+          rcmail::get_instance()->output->show_message('mel_moncompte.absence_ok', 'confirmation');
+        } else {
+          rcmail::get_instance()->output->show_message(rcmail::get_instance()->gettext('mel_moncompte.absence_nok') . ' : ' . $err, 'error');
+          return false;
+        }
       }
     } else {
       // Erreur d'auth


### PR DESCRIPTION
Si l'on ne modifie aucune valeur (message ou date) et que l'on clique sur enregistrer il y a un message d'erreur. Même soucis depuis l'avatar et l'accès rapide ou depuis l'écran de Configuration.