### PR TITLE
recette - 0008134 - :safety_vest: Les accents et caractères spéciaux ne fonctionnaient pas lors de la modification du sujet d'un mail

### DIFF
--- a/plugins/mel_metapage/mel_metapage.php
+++ b/plugins/mel_metapage/mel_metapage.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Plugin Mél Métapage
  *
@@ -2872,7 +2873,7 @@ class mel_metapage extends bnum_plugin
 
         if ($subject) $mail_raw = preg_replace(
             '/^Subject:.*(?:\r?\n[ \t].*)*/mi', // Expression régulière pour trouver la ligne commençant par "Subject: "
-            'Subject: '. Mail_mimePart::encodeHeader('Subject', $subject), // Remplacement par la nouvelle valeur de $subject
+            'Subject: ' . Mail_mimePart::encodeHeader('Subject', $subject, 'utf-8'), // Remplacement par la nouvelle valeur de $subject
             $mail_raw
         );
 


### PR DESCRIPTION
> Comme dans le courrielleur, permettre de modifier le sujet d'un Mél via l'utilisation de Commentaire

Le charset utilisé pour l'encodage n'était pas bon.