### PR TITLE
0008942 - :bug: Si la configuration du dossier des éléments envoyés est `---`

### DIFF
--- a/plugins/mel/mel.js
+++ b/plugins/mel/mel.js
@@ -200,10 +200,10 @@ if (window.rcmail) {
           .addClass('form-control custom-select pretty-select')
           .change();
 
-        let $select = $('#compose-options select[name="_store_target"]')[0];
+        let $select = $('#compose-options select[name="_store_target"]');
 
-        if ($select.value === '') {
-          $select.value = evt.response.sended_folder;
+        if ($select.val() === '') {
+          $select.val(evt.response.sended_folder).change();
         }
 
         $select = null;


### PR DESCRIPTION
Lorsque l'on change d'indentitée lors de la rédaction d'un mail, si l'identitée choisie à `---` comme dossier par défaut, le changement de dossier de sauvegarde n'est pas efféctué. Et le mail n'est pas sauvegardé.