### PR TITLE
0008947 - :bug: Il ne faut pas rajouter les membres de l'espace en modification

### DIFF
--- a/plugins/mel_workspace/js/lib/program/addons/calendar/calendar_additions.js
+++ b/plugins/mel_workspace/js/lib/program/addons/calendar/calendar_additions.js
@@ -60,8 +60,9 @@ class CalendarAddition extends WorkspaceObject {
     } else {
       //Si on ne passe pas par le bouton "créer" de l'espace de travail, mais par l'agenda
       //Lorsque la vue de la création d'un évènement de l'agenda est chargé, on ajoute les utilisateurs de l'espace de travail dans la liste des participants
-      this.listen('calendar.view.loaded', () => {
-        this.rcmail().command('calendar-workspace-add-all');
+      this.listen('calendar.view.loaded', (view) => {
+        if (!view.view._event.uid)
+          this.rcmail().command('calendar-workspace-add-all');
       });
     }
   }


### PR DESCRIPTION
Suite a la pr #129 qui ajoute tous les membres de l'espace lors de la création d'un évènement rattaché à l'espace, il ne faut pas faire cela en modification de l'évènement créé car on a pu supprimer des membres volontairement et ils sont de nouveau présents.