### PR TITLE
0008949 - :bug: Les menu de gauche disparaissent après avoir ouvert une liste de diffusion

### DIFF
--- a/plugins/annuaire/annuaire.php
+++ b/plugins/annuaire/annuaire.php
@@ -21,7 +21,7 @@
 
 require_once 'lib/drivers/driver_annuaire.php';
 
-class annuaire extends rcube_plugin
+class annuaire extends bnum_plugin
 {
     /**
      *
@@ -89,6 +89,10 @@ class annuaire extends rcube_plugin
 
             // use jQuery for draggable item
             $this->require_plugin('jqueryui');
+
+            if ($this->rc->action === 'show') {
+                $this->include_module('show.js');
+            }
 
             if ($this->rc->action == 'plugin.annuaire') {
                 // register UI objects

--- a/plugins/annuaire/js/lib/show.js
+++ b/plugins/annuaire/js/lib/show.js
@@ -1,0 +1,68 @@
+import ABaseMelObject from '../../../mel_metapage/js/lib/base_mel_object.js';
+
+/**
+ * @typedef {Object} RcubeSpyUrlArgs
+ * @property {jQuery} $target - L'élément cible de l'événement.
+ * @property {Event} e - L'événement intercepté.
+ * @property {boolean} [break] - Indique si l'exécution doit être interrompue.
+ * @package
+ */
+
+/**
+ * Classe représentant l'affichage d'un contact.
+ * @class
+ * @extends ABaseMelObject
+ */
+export default class ContactShow extends ABaseMelObject {
+  /**
+   * Constructeur de la classe ContactShow.
+   */
+  constructor() {
+    super();
+  }
+
+  /**
+   * Méthode principale de la classe.
+   * Initialise un écouteur pour intercepter les URL contenant "addressbook" et "show".
+   *
+   * @returns {ContactShow} L'instance actuelle de la classe.
+   */
+  main() {
+    return this.listen(
+      'rcube_spy_url',
+      this.#_actionRcubeSpyUrlCallback.bind(this),
+    );
+  }
+
+  /**
+   * Action a exécuter lorsque le trigger `rcube_spy_url` est appelé.
+   * @param {RcubeSpyUrlArgs} args
+   * @returns {RcubeSpyUrlArgs}
+   * @private
+   */
+  #_actionRcubeSpyUrlCallback(args) {
+    const { $target, e } = args;
+    const url = $target.attr('href');
+
+    // Prendre en compte seulement les urls vers l'annuaire
+    if (url && url.includes('addressbook') && url.includes('show')) {
+      e.preventDefault();
+      this.switch_url(url);
+      args.break = true;
+    }
+
+    return args;
+  }
+
+  /**
+   * Méthode statique pour démarrer l'affichage d'un contact.
+   *
+   * @returns {ContactShow} Une nouvelle instance de ContactShow initialisée.
+   */
+  static Start() {
+    return new ContactShow().main();
+  }
+}
+
+// Démarrage automatique de l'affichage d'un contact.
+ContactShow.Start();

--- a/plugins/mel_metapage/js/init/events.js
+++ b/plugins/mel_metapage/js/init/events.js
@@ -2329,6 +2329,24 @@ $(document).ready(() => {
           return;
         else if ($target.parent().parent().parent().attr('id') === 'taskmenu')
           return;
+        else {
+          // Permet de laisser les plugins de gérer l'interception des liens comme ils le souhaitent
+          const value = rcmail.triggerEvent('rcube_spy_url', {
+            break: false,
+            $target,
+            e: event,
+            intercept,
+          }) ?? { break: false };
+
+          // Si il y a plusieurs valeurs de retour, on les traites
+          if (value.length) {
+            for (const iterator of value) {
+              if (iterator.break === true) return;
+            }
+          }
+          // Sinon on traite la valeur de retour
+          else if (value.break === true) return;
+        }
       }
 
       //On ferme la modal


### PR DESCRIPTION
> Lorsque l'on clique sur une liste dans l'onglet "Liste de diffusion" dans la page de contact d'une personne dans l'annuaire, la liste s'ouvre en pleine page faisant disparaître les autres menus.