### PR TITLE
recette - 0008960 - :ambulance: Ajout d'un externe impossible

### DIFF
--- a/plugins/mel/lib/drivers/mtes/mtes.php
+++ b/plugins/mel/lib/drivers/mtes/mtes.php
@@ -899,7 +899,7 @@ class mtes_driver_mel extends mce_driver_mel
     $names = explode('@', strtolower($email), 2);
     if (strpos($names[0], '.') === false) {
       $lastname = strtoupper($names[0]);
-      $fistname = ' ';
+      $fistname = 'Externe';
     } else {
       $names = explode('.', $names[0]);
       $lastname = strtoupper($names[1]);


### PR DESCRIPTION
Impossible d'ajouter un externe qui n'est pas encore associé à un espace de travail.

"Les personnes ajoutées ne font pas partie de l'annuaire... Elles ne sont donc pas ajoutées à l'espace" s'affiche.

 Analyse TPA
 Bug si l'adresse n'est pas connue de l'annuaire (comprendre que l'externe n'a pas été préalablement associé à un autre espace) et si l'adresse ne comporte pas de '.' avant le nom de domaine (avant @)