### PR TITLE
0008946 - 🐛 Erreur dans la fonction "Ecrire aux participants"

### DIFF
--- a/plugins/mel_workspace/js/lib/program/actions/page.workspace.js
+++ b/plugins/mel_workspace/js/lib/program/actions/page.workspace.js
@@ -133,7 +133,7 @@ export class WorkspacePage extends WorkspaceObject {
 
           // eslint-disable-next-line no-case-declarations
           const mails = MelEnumerable.from(this.workspace.users.emails)
-            .where((x) => x !== MelCurrentUser.main_email)
+            .where((x) => x && x !== MelCurrentUser.main_email)
             .take(300)
             .join(',');
 


### PR DESCRIPTION
>Impossible d'écrire aux participants si une adresse mail incorrecte éxistait dans une liste.