### PR TITLE
0008918 - ✨ Rajouter une option calendly dans le générateur de signature

### DIFF
--- a/plugins/bnum_agenda/bnum_agenda.php
+++ b/plugins/bnum_agenda/bnum_agenda.php
@@ -7,15 +7,24 @@ class bnum_agenda extends bnum_plugin {
    * Tâches supportées par ce plugin.
    * @var string
    */
-  public $task = 'agenda|calendar';
+  public $task = 'agenda|calendar|settings';
 
   /**
    * Initialise le plugin et enregistre les actions nécessaires.
    *
    * @return void
    */
-  function init() {
-    $this->register_action('get_categories', [$this, 'action_get_categories']);
+  public function init() {
+    switch ($this->get_current_task()) {
+      case 'agenda':
+      case 'calendar':
+        $this->register_action('get_categories', [$this, 'action_get_categories']);
+        break;
+      
+      default:
+        $this->add_hook('signature.links', [$this, 'hook_signature_links']);
+        break;
+    }    
   }
 
   /**
@@ -65,5 +74,25 @@ class bnum_agenda extends bnum_plugin {
    */
   public function action_get_categories() : never {
     $this->sendEncodedExit(json_encode($this->get_categories()));
+  }
+
+  public function hook_signature_links($args) {
+    $checkbox = new html_checkbox();
+    $custom_links = $args['custom_links'] ?? '';
+    /**
+     * @var calendar
+     */
+    $calendar =$this->api->get_plugin('calendar');
+    $hasUrl = $calendar->get_appointment_url(driver_mel::gi()->getUser()->getDefaultCalendar()->id);
+
+    if ($hasUrl) {
+      $text = 'Lien vers le calendly';
+      $custom_links.=  html::tag('li', [], $checkbox->show('', ['value' => $hasUrl, 'id' => 'checkbox-calendly-link', 'onchange' => 'onInputChange();']) . html::label(['for' => "checkbox-calendly-link"], $text));
+
+      $args['env_links'][$hasUrl] = "Prenez rendez-vous avec moi ici !";
+      $args['custom_links'] = $custom_links;
+    }
+
+    return $args;
   }
 }

--- a/plugins/bnum_agenda/bnum_agenda.php
+++ b/plugins/bnum_agenda/bnum_agenda.php
@@ -77,6 +77,7 @@ class bnum_agenda extends bnum_plugin {
   }
 
   public function hook_signature_links($args) {
+    $this->add_texts('localization/');
     $checkbox = new html_checkbox();
     $custom_links = $args['custom_links'] ?? '';
     /**
@@ -86,10 +87,10 @@ class bnum_agenda extends bnum_plugin {
     $hasUrl = $calendar->get_appointment_url(driver_mel::gi()->getUser()->getDefaultCalendar()->id);
 
     if ($hasUrl) {
-      $text = 'Lien vers le calendly';
+      $text = $this->rc()->gettext('calendlink', 'bnum_agenda');
       $custom_links.=  html::tag('li', [], $checkbox->show('', ['value' => $hasUrl, 'id' => 'checkbox-calendly-link', 'onchange' => 'onInputChange();']) . html::label(['for' => "checkbox-calendly-link"], $text));
 
-      $args['env_links'][$hasUrl] = "Prenez rendez-vous avec moi ici !";
+      $args['env_links'][$hasUrl] = $this->rc()->gettext('calendlink-label', 'bnum_agenda');
       $args['custom_links'] = $custom_links;
     }
 

--- a/plugins/bnum_agenda/localization/fr_FR.inc
+++ b/plugins/bnum_agenda/localization/fr_FR.inc
@@ -1,0 +1,3 @@
+<?php
+$labels['calendlink'] = 'Lien vers la prise de rendez-vous';
+$labels['calendlink-label'] = 'Pour prendre rendez-vous : cliquez ici';

--- a/plugins/mel_signatures/mel_signatures.php
+++ b/plugins/mel_signatures/mel_signatures.php
@@ -18,7 +18,7 @@
 * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-class mel_signatures extends rcube_plugin
+class mel_signatures extends bnum_plugin
 {
     /**
      *
@@ -341,13 +341,16 @@ class mel_signatures extends rcube_plugin
 
         $attrib['class'] = "dropdown-check-list";
         
-        $links = "";
+        $links = '';
+        $custom_links = '';
         $env_links = [];
         $checkbox = new html_checkbox();
         $i = 1;
 
         $default_url = $this->get_default_url();
         $links .= html::tag('li', [], $checkbox->show("", ['value' => 'custom-link', 'id' => "checkbox-custom-link", 'onchange' => 'onInputChange();']) . html::label(['for' => "checkbox-custom-link"], $this->gettext('customlink')));
+        // Prise en compte des liens personnalisés. Permet d'ajouter des liens en prioritée.
+        $links .= '{{custom_links}}';
         $signature_links = $this->rc->config->get('signature_links', []);
         foreach ($signature_links as $name => $link) {
             $id = "signature_links_$i";
@@ -355,6 +358,19 @@ class mel_signatures extends rcube_plugin
             $env_links[$link] = $name;
             $links .= html::tag('li', ['title' => $name], $checkbox->show($signature_links[$default_url], ['value' => $link, 'id' => $id, 'onchange' => 'onInputChange();']) . html::label(['for' => $id], $name));
         }
+
+        $plugin = $this->exec_hook('signature.links', ['custom_links' => '', 'links' => $links, 'env_links' => $env_links, 'signature_links' => $signature_links, 'attribs' => $attrib]);
+
+        if ($plugin) {
+            $custom_links = $plugin['custom_links'] ?? '';
+            $links = $plugin['links'] ?? $links;
+            $env_links = $plugin['env_links'] ?? $env_links;
+            $attrib = array_merge($attrib, $plugin['attribs'] ?? []);
+        }
+
+        // Si on a des liens personnalisés, on les ajoute
+        $links = str_replace('{{custom_links}}', $custom_links, $links);
+
         $this->rc->output->set_env('signature_links', $env_links);
         return html::div($attrib,
             html::span(['class' => 'anchor'], $this->gettext('linksselection')) .


### PR DESCRIPTION
>Rajouter une option dans "choix des liens" pour pouvoir rajouter directement un lien vers le calendly de l'utilisateur 
>Le message serait plus court que l'url du type : "Pour prendre rendez-vous : cliquez-ici"
