### PR TITLE
0008564 - :speech_balloon: Faute lorsque le champs "Ajouter une audioconférence" est vide.

### DIFF
--- a/plugins/mel_metapage/localization/fr_FR.inc
+++ b/plugins/mel_metapage/localization/fr_FR.inc
@@ -484,11 +484,11 @@ $labels['existing_guest'] = 'Le participant %0 éxiste déjà !';
 $labels['add_guests'] = 'Ajoutez des participants';
 $labels['req_guest'] = 'Participants obligatoires';
 
-$labels['error_empty_event_visio_room'] = 'Le nom de la visioconférence ne doit être vide !';
+$labels['error_empty_event_visio_room'] = 'Le nom de la visioconférence ne doit pas être vide !';
 $labels['error_too_small_event_visio_room'] = 'Le nom de la visioconférence doit avoir au moins 10 charactères !';
 $labels['error_less_number_event_visio_room'] = 'Le nom de la visioconférence doit avoir au moins 3 chiffres !';
 $labels['unknown_error'] = 'Erreur inconnue !';
-$labels['error_empty_event_audio'] = 'Le numéro de téléphone ne doit être vide !';
+$labels['error_empty_event_audio'] = 'Le numéro de téléphone ne doit pas être vide !';
 
 $labels['found_audio_date'] = 'Réserver une audio-conférence';
 $labels['add'] = 'Ajouter';


### PR DESCRIPTION
>Il est actuellement écrit "Le numéro de téléphone ne doit être vide !
>Modifier le texte pour rajouter le "pas".
