### PR TITLE
0008968 - :bug: Décalage dans l'affichage des plannings de moins d'une heure et non prise en compte des evts de l'agenda

### DIFF
--- a/plugins/mel_workspace/js/lib/WebComponents/planning.js
+++ b/plugins/mel_workspace/js/lib/WebComponents/planning.js
@@ -52,7 +52,7 @@ export class Planning extends HtmlCustomDataTag {
     this.#eventsSource = new EventSourceLoader('planning-events');
     this.#resourceSource = new (
       this.workspace.isPublic ? PublicResourceLoader : ResourcesSourceLoader
-    )('planning-resources', this.slotDurationTime, this);
+    )('planning-resources', 30, this);
 
     this._nextLoad = false;
     this._dateHeader = null;


### PR DESCRIPTION
On affiche désormait demi-heure par demi-heure. Plus fin alourdirais les temps de chargements.
