### PR TITLE
recette - 0008403 - Correction du code pour affichage correcte des title des boutons resync et suppression mobile

### DIFF
--- a/plugins/mel_labels_sync/localization/fr_FR.inc
+++ b/plugins/mel_labels_sync/localization/fr_FR.inc
@@ -34,3 +34,5 @@ $labels['redirected'] = 'Redirigé';
 $labels['labels_filter_placeholder'] = 'Filtrer les étiquettes';
 
 $labels['labels_editable_by_gestionnaire'] = 'Vous devez être gestionnaire de la boite pour pouvoir modifier ses étiquettes.';
+
+$labels['empty_label_error'] = 'Il n\'est pas possible d\'enregistrer une étiquette sans nom';

--- a/plugins/mel_labels_sync/mel_labels_sync.php
+++ b/plugins/mel_labels_sync/mel_labels_sync.php
@@ -400,7 +400,7 @@ class mel_labels_sync extends rcube_plugin
    */
   function set_flags()
   {
-    $imap = $this->rc->storage;
+    $imap = $this->rc->imap;
     $cbox = rcube_utils::get_input_value('_cur', rcube_utils::INPUT_GET);
     $mbox = rcube_utils::get_input_value('_mbox', rcube_utils::INPUT_GET);
     $toggle_label = rcube_utils::get_input_value('_toggle_label', rcube_utils::INPUT_GET);
@@ -654,6 +654,18 @@ class mel_labels_sync extends rcube_plugin
       $_post_labels = (array) rcube_utils::get_input_value('_labels', rcube_utils::INPUT_POST);
       $_post_colors = (array) rcube_utils::get_input_value('_colors', rcube_utils::INPUT_POST);
       $old_labels = $this->driver->get_user_labels($this->_get_current_user_name());
+
+      // Détecter les étiquettes vides 
+      $empty_labels = array_filter($_post_labels, function ($name) {
+        return is_string($name) && trim($name) !== '';
+      });
+
+      // Si rien à sauvegarder générer un message d'erreur
+      if (empty($empty_labels)) {
+        $this->rc->output->command('display_message', $this->gettext('empty_label_error'), 'error');
+        $p['abort'] = true; // Empêche le message de succès par défaut
+        return $p;
+      }
 
       // Parcours des labels retournés par le post
       foreach ($_post_labels as $key => $label_name) {

--- a/plugins/mel_moncompte/statistiques/mobile.php
+++ b/plugins/mel_moncompte/statistiques/mobile.php
@@ -346,20 +346,20 @@ class Mobile_Stats
                         'mel_moncompte.first_sync' => $firstsync,
                         'mel_moncompte.last_sync' => $lastsync,
                         'mel_moncompte.z-push' => $maxzpushvers,
-                        'mel_moncompte.resync' => html::tag('button', array(
+                        'mel_moncompte.resync' => ['html' => html::tag('button', [
                             'type' => 'button',
                             'class' => 'button resync',
                             'title' => $this->plugin->gettext('device_resync'),
                             'onclick' => "zpush_command('ResyncUserDevice', '$deviceId', '$userDevice')",
                             'tabindex' => '0'
-                        ), $this->plugin->gettext('device_resync')),
-                        'mel_moncompte.remove' => html::tag('button', array(
+                        ], $this->plugin->gettext('device_resync'))],
+                        'mel_moncompte.remove' => ['html' => html::tag('button', [
                             'type' => 'button',
                             'class' => 'button remove',
                             'title' => $this->plugin->gettext('device_remove'),
                             'onclick' => "zpush_command('DeleteUserDevice', '$deviceId', '$userDevice')",
                             'tabindex' => '0'
-                        ), $this->plugin->gettext('device_remove')),
+                        ], $this->plugin->gettext('device_remove'))],
                         'class' => '',
                     );
                 }
@@ -436,13 +436,13 @@ class Mobile_Stats
                                 'mel_moncompte.foldersync' => $folderidname,
                                 'mel_moncompte.last_sync' => $lastsync,
                                 'mel_moncompte.z-push' => $zpushversion,
-                                'mel_moncompte.resync' => html::tag('button', array(
+                                'mel_moncompte.resync' => ['html' => html::tag('button', [
                                     'type' => 'button',
                                     'class' => 'button resync',
                                     'title' => $this->plugin->gettext('device_resync'),
                                     'onclick' => "zpush_command('ResyncFolderId', '$deviceId', '$id_userFolder', '$id_folderid')",
                                     'tabindex' => '0'
-                                ), $this->plugin->gettext('device_resync')),
+                                ], $this->plugin->gettext('device_resync'))],
                                 'mel_moncompte.remaining' => $synced . " / " . $total,
                             );
                         }


### PR DESCRIPTION
Suite à une anomalie d'affichage remonté dans le cadre de la recette, correction du code pour affichage des valeur des title des boutons Resync et Suppression mobile.

Après review merci de push la correction en recette, afin qu'elle puisse être de nouveau testée. Pas possible de tester cette dernière en dev.