### PR TITLE
recette - 0008404 - Nouvelle correction pour affichage des valeurs concernant la liste des mobiles

### DIFF
--- a/plugins/mel_moncompte/mobile.js
+++ b/plugins/mel_moncompte/mobile.js
@@ -154,47 +154,6 @@ if (window.rcmail) {
       rcmail.mobiles_list.init();
       rcmail.mobiles_list.focus();
 
-      // Ajout dynamique des tooltips
-      var tooltips = rcmail.env.mobile_tooltips || [];
-      $('#rcmmobileslist tbody tr').each(function (index) {
-        var tips = tooltips[index];
-        if (!tips) return;
-
-        var $row = $(this);
-        $row
-          .find('td[data-column="mel_moncompte.deviceid"]')
-          .attr(
-            'title',
-            rcmail.gettext('deviceid_title', 'mel_moncompte') +
-              ': ' +
-              tips.deviceid,
-          );
-
-        $row
-          .find('td[data-column="mel_moncompte.type"]')
-          .attr(
-            'title',
-            rcmail.gettext('type_title', 'mel_moncompte') + ': ' + tips.type,
-          );
-
-        $row
-          .find('td[data-column="mel_moncompte.last_sync"]')
-          .attr(
-            'title',
-            rcmail.gettext('lastsync_title', 'mel_moncompte') +
-              ': ' +
-              tips.lastsync,
-          );
-
-        $row
-          .find('td[data-column="mel_moncompte.z-push"]')
-          .attr(
-            'title',
-            rcmail.gettext('zpush_title', 'mel_moncompte') + ': ' + tips.zpush,
-          );
-      });
-    }
-
     // Gestion des boutons désactivés
     if ($('#rcmaccountsinfo').length > 0) {
       $('#rcmaccountsinfo tbody tr').each(function () {

--- a/plugins/mel_moncompte/statistiques/mobile.php
+++ b/plugins/mel_moncompte/statistiques/mobile.php
@@ -346,20 +346,20 @@ class Mobile_Stats
                         'mel_moncompte.first_sync' => $firstsync,
                         'mel_moncompte.last_sync' => $lastsync,
                         'mel_moncompte.z-push' => $maxzpushvers,
-                        'mel_moncompte.resync' => html::tag('button', array(
+                        'mel_moncompte.resync' => ['html' => html::tag('button', [
                             'type' => 'button',
                             'class' => 'button resync',
                             'title' => $this->plugin->gettext('device_resync'),
                             'onclick' => "zpush_command('ResyncUserDevice', '$deviceId', '$userDevice')",
                             'tabindex' => '0'
-                        ), $this->plugin->gettext('device_resync')),
-                        'mel_moncompte.remove' => html::tag('button', array(
+                        ], $this->plugin->gettext('device_resync'))],
+                        'mel_moncompte.remove' => ['html' => html::tag('button', [
                             'type' => 'button',
                             'class' => 'button remove',
                             'title' => $this->plugin->gettext('device_remove'),
                             'onclick' => "zpush_command('DeleteUserDevice', '$deviceId', '$userDevice')",
                             'tabindex' => '0'
-                        ), $this->plugin->gettext('device_remove')),
+                        ], $this->plugin->gettext('device_remove'))],
                         'class' => '',
                     );
                 }
@@ -436,13 +436,13 @@ class Mobile_Stats
                                 'mel_moncompte.foldersync' => $folderidname,
                                 'mel_moncompte.last_sync' => $lastsync,
                                 'mel_moncompte.z-push' => $zpushversion,
-                                'mel_moncompte.resync' => html::tag('button', array(
+                                'mel_moncompte.resync' => ['html' => html::tag('button', [
                                     'type' => 'button',
                                     'class' => 'button resync',
                                     'title' => $this->plugin->gettext('device_resync'),
                                     'onclick' => "zpush_command('ResyncFolderId', '$deviceId', '$id_userFolder', '$id_folderid')",
                                     'tabindex' => '0'
-                                ), $this->plugin->gettext('device_resync')),
+                                ], $this->plugin->gettext('device_resync'))],
                                 'mel_moncompte.remaining' => $synced . " / " . $total,
                             );
                         }


### PR DESCRIPTION
Lors du test en recette, la correction précédente s'est avérée inutile. Nouvelle modification apportée afin que le html ne soit pas échappé et donc lu correctement.

Après la Review est il possible de pousser le code en recette afin d'être testé à nouveau, car test impossible en dev.