### PR TITLE
0009017 - :bug: Désactiver favikontoolkit

### DIFF
--- a/plugins/mel_useful_link/js/lib/mel_link.js
+++ b/plugins/mel_useful_link/js/lib/mel_link.js
@@ -394,6 +394,9 @@ class MelLinkVisualizer extends MelLink {
     //   icon = null;
     // }
     if (link && link.includes('https://')) link = null;
+
+    if (image && image.includes('https://')) image = null;
+
     super(id, title, link, inFolder);
     this._setup_image(image);
     this._setup_icon(icon);


### PR DESCRIPTION
>Dans un premier temps, on affichera juste les initials, puis on remettra les icônes en place.

Tous les liens n'avait pas l'initial.