### PR TITLE
9031 - ✨ Annuaire ajout d'un participant : La saisie du nom de participant reste même après avoir fermé la modale

### DIFF
--- a/plugins/annuaire/annuaire.js
+++ b/plugins/annuaire/annuaire.js
@@ -784,6 +784,7 @@ rcube_webmail.prototype.annuaire_set_show_contacts = function () {
       element
         .click(function (e) {
           $('#compose-contacts').focus().modal('show');
+          document.getElementById('contactsearchbox').value = '';
           if ($('#annuaire-list li').length == 0) {
             rcmail.annuaire_set_loading_icon();
             rcmail.http_get(


### PR DESCRIPTION
Lorsqu'on est sur l'edt est qu'on souhaite inviter un agent, si on recherche depuis l'annuaire intégré ( modale qui s'ouvre après le clic sur l'icone)On saisi le nom, et une fois trouvé le clic pour la sélection
ok
La coche verte indique bien que c'est bien ajouté ( c'est le résultat attendu et obtenu)Puis on ferme la modale
 On repart sur la modale pour rechercher un autre nom
Résultat : le dernier nom saisi est encore stocké
Résultat attendu: La saisie dans le champ doit se vider après chaque fermeture
