### PR TITLE
0008419 - :sparkles: Pouvoir sélectionner les courriels sans étiquettes

### DIFF
--- a/plugins/mel/localization/fr_FR.inc
+++ b/plugins/mel/localization/fr_FR.inc
@@ -157,6 +157,7 @@ $labels['label-unread'] =      'Non lus'              ;
 $labels['label-followed'] =    'Suivis'               ;
 $labels['label-attachment'] =  'Avec une pièce jointe';
 $labels['label-labels'] =      'Étiquettes'           ;
+$labels['label-nolabels'] =    'Sans étiquettes'      ;
 $labels['label-priority'] =    'Priorités'            ;
 $labels['label-noresponses'] = 'Sans réponses'        ;
 

--- a/plugins/mel/mel.php
+++ b/plugins/mel/mel.php
@@ -234,7 +234,7 @@ class mel extends rcube_plugin
 
         if (in_array($this->rc->action, ['', 'index'])) {
           $container = 'messagelistfiltersmenu';
-          $filters = ['all', 'unread', 'followed', 'labels', 'priority', 'attachment', 'noresponses'];
+          $filters = ['all', 'unread', 'followed', 'labels', 'nolabels', 'priority', 'attachment', 'noresponses'];
           //Filtres rapides
           foreach ($filters as $value) {
             $config = array(
@@ -257,6 +257,11 @@ class mel extends rcube_plugin
                 break;
               case 'labels':
                 $config['data-filter-custom-action'] = 'trigger:quick-filter.labels';
+                $config['data-filter-can-be-multiple'] = true;
+                break;
+
+                case 'nolabels':
+                $config['data-filter-custom-action'] = 'trigger:quick-filter.nolabels';
                 $config['data-filter-can-be-multiple'] = true;
                 break;
 

--- a/plugins/mel/mel_filters.js
+++ b/plugins/mel/mel_filters.js
@@ -655,6 +655,42 @@ les propriétés « nom » et « valeur ».
       mel_filter_manager.base_callback(filter, $caller, {});
     });
 
+    rcmail.addEventListener(
+      'quick-filter.nolabels',
+      /**
+       * Événement déclenché lorsqu'aucune étiquette (label) n'est sélectionnée dans les filtres rapides.
+       *
+       * Cet event permet de réinitialiser l'affichage des labels, de désactiver le filtre "labels",
+       * puis de construire une action de filtre qui exclut tous les labels connus.
+       * Enfin, il applique ce filtre via la callback de base.
+       *
+       * @event quick-filter.nolabels
+       * @param {Object} args - Les arguments de l'événement.
+       * @param {mel_filter} args.filter - Le filtre concerné.
+       * @param {jQuery} args.target_event - L'élément déclencheur de l'événement.
+       */
+      (args) => {
+        const { filter, target_event } = args;
+
+        // Réinitialise l'affichage des labels et retire l'état actif du bouton "labels"
+        mel_filter_manager.reset_labels();
+        $('#quick-filter-labels').removeClass('active');
+
+        // Construit une liste d'exclusion pour tous les labels connus
+        const labels = Object.keys(rcmail.env.labels_translate).map((key) => {
+          return (
+            'NOT KEYWORD ' +
+            key.replace('_-s-_', '$').replace('_-t-_', '~').toUpperCase()
+          );
+        });
+
+        // Met à jour l'action du filtre pour exclure tous les labels
+        filter.action = labels.join(' ');
+        // Applique le filtre via la callback standard
+        mel_filter_manager.base_callback(filter, target_event, {});
+      },
+    );
+
     rcmail.addEventListener('quick-filter.priority', async (args) => {
       let { filter, target_event } = args;
 


### PR DESCRIPTION
Ajout d'un filtre rapide "sans étiquettes".
![image](https://github.com/user-attachments/assets/fcc5e56e-7c14-4897-bec7-1465817068e3)
