### PR TITLE
0009030 - :bug: Ne pas importer les comptes avec une adresse email `null`.

### DIFF
--- a/plugins/mel_workspace/lib/Workspace.php
+++ b/plugins/mel_workspace/lib/Workspace.php
@@ -609,9 +609,16 @@ class Workspace {
         $list = [];
 
         foreach ($user->list->members as $value) {
-            $value = $value->uid;
-            $list[] = $value;
-            yield $value;
+          if ($value->uid === null) continue;
+
+          $user = driver_mel::gi()->getUser($value->uid);
+
+          if ($user === null || $user->email === null) continue;
+          unset($user);
+
+          $value = $value->uid;
+          $list[] = $value;
+          yield $value;
         }
 
         $lists = $this->settings()->get('lists') ?? [];//$this->get_setting($workspace, 'lists') ?? [];


### PR DESCRIPTION
>Certaines listes contienent des comptes qui n'ont pas d'adresses email. 
>Il faudrait ne pas les importer.

