### PR TITLE
0008421 - ✨ Augmenter le nombre de ligne par case dans l'affichage au mois dans Calendrier

### DIFF
--- a/plugins/bnum_agenda/bnum_agenda.php
+++ b/plugins/bnum_agenda/bnum_agenda.php
@@ -15,14 +15,18 @@ class bnum_agenda extends bnum_plugin {
    * @return void
    */
   public function init() {
+    $this->rc()->output->set_env('event_limit',$this->rc()->config->get('event_limit'));
     switch ($this->get_current_task()) {
       case 'agenda':
       case 'calendar':
         $this->register_action('get_categories', [$this, 'action_get_categories']);
+        $this->rc()->config->get('event_limit');
         break;
       
       default:
         $this->add_hook('signature.links', [$this, 'hook_signature_links']);
+        $this->add_hook('preferences_list', [$this, 'hook_preferences_list']);
+        $this->add_hook('preferences_save', [$this, 'hook_preferences_save']);
         $this->add_hook('folder_update', [$this, 'hook_folder_update']);
         break;
     }    
@@ -127,6 +131,70 @@ class bnum_agenda extends bnum_plugin {
 
       $this->rc()->user->save_prefs(['folders_colors' => $prefs]);
         
+    return $args;
+  }
+
+  /**
+   * Hook Roundcube pour mettre à jour la couleur d'un dossier.
+   *
+   * Ce hook permet de sauvegarder la couleur associée à un dossier lors de sa modification.
+   *
+   * @param array $args Tableau des arguments transmis par Roundcube lors de la mise à jour d'un dossier.
+   * @return array Tableau des arguments, inchangé.
+   */
+  public function hook_folder_update($args) {
+    $this->load_config();
+    $color = $this->get_input_post('_color') ?? null;
+
+    if ($color === '') $color = null;
+      $folder = $this->get_input_post('_mbox');
+      $prefs = $this->rc()->config->get('folders_colors', []);
+
+      if (isset($color)) $prefs[$folder] = $color;
+      else unset($prefs[$folder]);
+
+      $this->rc()->user->save_prefs(['folders_colors' => $prefs]);
+        
+    return $args;
+  }
+
+  /**
+   * Hook Roundcube pour afficher l'option nombre d'évenements affichés dans l'agenda.
+   *
+   * @param array $args Tableau des arguments transmis par Roundcube lors de la mise à jour d'un dossier.
+   * @return array Tableau des arguments, inchangé.
+   */
+  public function hook_preferences_list($args) {
+    if ($args['section'] === 'calendar') {
+      $this->add_texts('localization/');
+      
+      $field_id = 'event_limit';
+      $select = new html_select(['name' => '_event_limit', 'id' => $field_id]);
+      for ($i=2; $i <= 6; $i++) { 
+        $select->add("$i", $i);
+      }
+
+      $args['blocks']['view']['options']['event_limit'] = [
+        'title'   => html::label($field_id, rcube::Q($this->gettext('event_limit'))),
+        'content' => $select->show(intval($this->rc()->config->get('event_limit', 4))),
+      ];
+    }
+    return $args;
+  }
+
+  /**
+   * Hook Roundcube pour mettre à jour le nombre d'évenements affichés dans l'agenda.
+   *
+   * Ce hook permet de sauvegarder le nombre d'évenements affichés dans l'agenda lors de sa modification.
+   *
+   * @param array $args Tableau des arguments transmis par Roundcube lors de la mise à jour d'un dossier.
+   * @return array Tableau des arguments, inchangé.
+   */
+  public function hook_preferences_save($args) {
+    if ($args['section'] === 'calendar') {
+      $args['prefs']['event_limit'] = rcube_utils::get_input_value('_event_limit', rcube_utils::INPUT_POST);
+      $this->rc()->output->set_env('event_limit', $args['prefs']['event_limit']);
+    }
     return $args;
   }
 }

--- a/plugins/bnum_agenda/config.inc.php.dist
+++ b/plugins/bnum_agenda/config.inc.php.dist
@@ -1,2 +1,3 @@
 <?php
 $config['calendar_task'] = 'calendar';
+$config['event_limit'] = 4;

--- a/plugins/bnum_agenda/localization/fr_FR.inc
+++ b/plugins/bnum_agenda/localization/fr_FR.inc
@@ -1,3 +1,4 @@
 <?php
 $labels['calendlink'] = 'Lien vers la prise de rendez-vous';
 $labels['calendlink-label'] = 'Pour prendre rendez-vous : cliquez ici';
+$labels['event_limit'] = 'Nombres maximum d\'évènements affichés';

--- a/plugins/calendar/calendar_ui.js
+++ b/plugins/calendar/calendar_ui.js
@@ -115,12 +115,14 @@ function rcube_calendar_ui(settings) {
       month: {
         columnFormat: 'ddd', // Mon
         titleFormat: 'MMMM YYYY',
-        eventLimit: 4,
+        //PAMELA - Choix du nombre d'event à afficher
+        eventLimit: +rcmail.env.event_limit,
       },
       monthWork: {
         columnFormat: 'ddd', // Mon
         titleFormat: 'MMMM YYYY',
-        eventLimit: 4,
+        //PAMELA - Choix du nombre d'event à afficher
+        eventLimit: +rcmail.env.event_limit,
         hiddenDays: [0, 6],
       },
       // PAMELA - View week days of work
@@ -129,7 +131,8 @@ function rcube_calendar_ui(settings) {
         titleFormat: settings.dates_long,
         hiddenDays: [0, 6],
         // Problème avec les journées entières
-        eventLimit: 4,
+        //PAMELA - Choix du nombre d'event à afficher
+        eventLimit: +rcmail.env.event_limit,
       },
       // PAMELA - Fullcalendar premium
       agendaResource: {
@@ -152,7 +155,8 @@ function rcube_calendar_ui(settings) {
         groupByResource: true,
         groupByDateAndResource: true,
         // PAMELA - Problème avec les journées entières
-        eventLimit: 4,
+        //PAMELA - Choix du nombre d'event à afficher
+        eventLimit: +rcmail.env.event_limit,
       },
       agendaThreeDay: {
         type: 'agenda',
@@ -161,19 +165,22 @@ function rcube_calendar_ui(settings) {
         groupByResource: true,
         groupByDateAndResource: true,
         // PAMELA - Problème avec les journées entières
-        eventLimit: 4,
+        //PAMELA - Choix du nombre d'event à afficher
+        eventLimit: +rcmail.env.event_limit,
       },
       week: {
         columnFormat: 'ddd ' + settings.date_short, // Mon 9/7
         titleFormat: settings.dates_long,
         // PAMELA - Problème avec les journées entières
-        eventLimit: 4,
+        //PAMELA - Choix du nombre d'event à afficher
+        eventLimit: +rcmail.env.event_limit,
       },
       day: {
         columnFormat: 'dddd ' + settings.date_short, // Monday 9/7
         titleFormat: 'dddd ' + settings.date_long,
         // PAMELA - Problème avec les journées entières
-        eventLimit: 4,
+        //PAMELA - Choix du nombre d'event à afficher
+        eventLimit: +rcmail.env.event_limit,
       },
     },
     timeFormat: settings.time_format,

--- a/plugins/calendar/localization/fr_FR.inc
+++ b/plugins/calendar/localization/fr_FR.inc
@@ -12,6 +12,8 @@ $labels['timeslots'] = 'Créneau horaire';
 $labels['first_day'] = 'Premier jour de la semaine';
 $labels['first_hour'] = 'Première heure à afficher';
 $labels['workinghours'] = 'Heures de travail';
+// PAMELA
+$labels['event_limit'] = 'Nombres maximum d\'évènements affichés';
 $labels['add_category'] = 'Ajouter une catégorie';
 $labels['remove_category'] = 'Supprimer une catégorie';
 $labels['defaultcalendar'] = 'Ajouter un nouvel événement';

--- a/plugins/mel_metapage/js/functions.js
+++ b/plugins/mel_metapage/js/functions.js
@@ -3398,7 +3398,7 @@ async function m_mp_ToggleGroupOptionsUser(opener) {
 /**
  * Permet de sauvegarder une option rapide
  */
-function save_option(_option_name, _option_value, element) {
+function save_option(_option_name, _option_value, element, reload = false) {
   element = $(element);
   const name = element.attr('name');
 
@@ -3432,6 +3432,9 @@ function save_option(_option_name, _option_value, element) {
         if (func)
           rcmail.command(func, { key: _option_name, value: parsed_datas });
         else rcmail.command('refreshFrame');
+      }
+      if (reload) {
+        rcmail.command('refreshFrame');
       }
     },
   );

--- a/plugins/mel_metapage/js/init/events.js
+++ b/plugins/mel_metapage/js/init/events.js
@@ -416,6 +416,24 @@ if (rcmail && window.mel_metapage) {
     });
 
     if (rcmail.env.task === 'settings') {
+      if(parent.rcmail.env.event_limit && parent.rcmail.env.event_limit !==
+        rcmail.env.event_limit
+      ) {
+        parent.rcmail.env.event_limit = rcmail.env.event_limit;
+        (async () => {
+          const manager = await (async () => {
+            try {
+              return PageManager.Instance; 
+            } catch (error) {
+              return await PageManager.Load();
+            }
+          })();
+
+          if(manager.Instance.has_frame('calendar')){
+            manager.Instance.get_window().remove_frame('calendar');
+          }
+        })();
+      }
       if (
         top.rcmail.env.avatar_background_color !==
         rcmail.env.avatar_background_color

--- a/plugins/mel_metapage/skins/mel_elastic/templates/options/calendar.html
+++ b/plugins/mel_metapage/skins/mel_elastic/templates/options/calendar.html
@@ -57,4 +57,17 @@
       </select>
     </div>
   </div>
+  <div class="row mt-3">
+    <div class="col-12">
+      <div><roundcube:label name='calendar.event_limit'/></div>
+      <select data-command="redraw_aganda" name="event_limit" id="rcmfd_event_limit" class="form-control custom-select pretty-select"
+        onchange="save_option('event_limit', this.value, this, true)">
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+        <option value="5">5</option>
+        <option value="6">6</option>
+      </select>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
ssu du module suggestion :

L'agenda, affiché au mois, affiche jusqu'à 4 évènements par jour
Dès qu'on passe à 5, il est nécessaire de cliquer sur "voir plus"
Si possible d'augmenter la limite de 1 :-)

A mettre en conf