### PR TITLE
0009092 - 🐛 Pouvoir partager agenda ou bal depuis le CN et non l'uid

### DIFF
--- a/plugins/mel_acl/mel_acl.php
+++ b/plugins/mel_acl/mel_acl.php
@@ -777,10 +777,10 @@ class mel_acl extends rcube_plugin
             'uid'  => $uid_field,
         );
 
-        // search in UID and name fields
+        // only search in name field
         // $name_field can be in a form of <field>:<modifier> (#1490591)
         $name_field = preg_replace('/:.*$/', '', $name_field);
-        $search     = array_unique(array($name_field, $uid_field));
+        $search     = array($name_field);
 
         $config['search_fields']   = $search;
         $config['required_fields'] = array($uid_field);


### PR DESCRIPTION
Le plugin mel_acl demandait une recherche par name et uid qui se transformait par uid uniquement. La recherche par uid n'a pas de sens, on n'a besoin que la recherche par name (qui fonctionne quand elle est seule).

Ce ticket fait suite a une régression suite au passage en RC 1.6 où on a perdu un patch pour forcer la recherche ldap par name pour des raisons de performances. On essaye de pas le reprendre et on voit