### PR TITLE
0009086 - :sparkles: Réserver une ressource devrait créer un événement en occupé

### DIFF
--- a/plugins/mel_cal_resources/config.inc.php.dist
+++ b/plugins/mel_cal_resources/config.inc.php.dist
@@ -11,6 +11,8 @@ $config['rc_resources'] = [
         'is_option' => true,
         //Fonction de la ressource dans driver_mel
         'load_data' => 'resources_flex_office',
+        //A la sauvegarde de la ressource mettre l'évènement en occupé ou non (true par défaut)
+        'busy' => false
     ]
 ];
 

--- a/plugins/mel_cal_resources/js/add_resources.js
+++ b/plugins/mel_cal_resources/js/add_resources.js
@@ -44,6 +44,7 @@ export { ResourceDialog };
  * @property {string} name Nom de la ressource
  * @property  {boolean} is_option Si la ressource doit être affiché dans la liste des modes d'évènements ou non
  * @property {string} load_data Nom de la fonction qui permettra de récupérer les données de la ressource associée
+ * @property {boolean} [busy=true] Si la ressource est occupée ou non. Si true, on ne peut pas la réserver.
  */
 
 /**
@@ -466,8 +467,20 @@ class ResourceDialog extends MelObject {
     this._location.onchange.call();
 
     //Changer le status si besoin
-    if (!(EventView.INSTANCE.parts.status._$field.val() || false))
+    if (
+      !(EventView.INSTANCE.parts.status._$field.val() || false) &&
+      !(
+        this.get_env('cal_resources')?.resources?.[this._resource_type]?.busy ??
+        true
+      )
+    )
       EventView.INSTANCE.parts.status._$field.val('FREE').change();
+    else if (
+      !EventView.INSTANCE.parts.status._$field.val() &&
+      (this.get_env('cal_resources')?.resources?.[this._resource_type]?.busy ??
+        true)
+    )
+      EventView.INSTANCE.parts.status._$field.val('CONFIRMED').change();
 
     //Changer la réccurence
     EventView.INSTANCE.parts.recurrence._$fakeField


### PR DESCRIPTION
>Contrairement au flex office ou la création en libre est logique, pour une ressource (salle, véhicule) il vaudrait mieux laisser le comportement par défaut avec occupé (et au pire l'utilisateur change si besoin).

ADDED: Busy in config