### PR TITLE
0009087 - :sparkles: Dans la popup de ressources faire le lien entre utilisateur et ville via le code postal

### DIFF
--- a/plugins/mel_cal_resources/js/add_resources.js
+++ b/plugins/mel_cal_resources/js/add_resources.js
@@ -524,11 +524,18 @@ class ResourceDialog extends MelObject {
    * @private
    */
   #_autoSelectOption() {
-    let option = Utils.GetOptionByDescription(this.get_env('user_location'));
+    let option =
+      Utils.GetOptionByPostalCode(
+        this.get_env('user_postalcode') ?? EMPTY_STRING,
+      ) ||
+      Utils.GetOptionByDescription(
+        (this.get_env('user_location') ?? EMPTY_STRING).toUpperCase(),
+      );
 
-    if (option.length) {
-      const value = option.attr('value');
-      option.parent().val(value).change();
+    if (option) {
+      const value = option.getAttribute('value');
+      option.parentElement.value = value;
+      option.parentElement.dispatchEvent(new Event('change'));
     }
 
     option = null;

--- a/plugins/mel_cal_resources/js/lib/filter_base.js
+++ b/plugins/mel_cal_resources/js/lib/filter_base.js
@@ -264,7 +264,7 @@ class FilterBase extends MelObject {
             .each(
               (jhtml, locality) => {
                 return jhtml
-                  .option({ value: locality.uid, 'data-description': locality.description })
+                  .option({ value: locality.uid, 'data-postalcode': locality.postalcode, 'data-description': locality.description })
                   .text(locality.name)
                   .end();
               },

--- a/plugins/mel_cal_resources/js/lib/utils.js
+++ b/plugins/mel_cal_resources/js/lib/utils.js
@@ -10,12 +10,23 @@ class Utils {
 
   /**
    * Récupère une option via le `data-description`
-   * @param {string} description Description de la resosurce
-   * @returns {external:jQuery}
+   * @param {string} description Description de la ressource
+   * @returns {?HTMLOptionElement}
    */
   static GetOptionByDescription(description) {
-    return $(
+    return document.querySelector(
       `.mel-dialog-page select option[data-description="${description.toUpperCase()}"]`,
+    );
+  }
+
+  /**
+   * Récupère une option via le `data-postalcode`
+   * @param {string} code Code postal de la ressource
+   * @returns {?HTMLOptionElement}
+   */
+  static GetOptionByPostalCode(code) {
+    return document.querySelector(
+      `.mel-dialog-page select option[data-postalcode="${code}"]`,
     );
   }
 }

--- a/plugins/mel_cal_resources/lib/Locality.php
+++ b/plugins/mel_cal_resources/lib/Locality.php
@@ -1,19 +1,53 @@
 <?php
+
+/**
+ * Classe représentant une localité.
+ *
+ * Cette classe permet de stocker et manipuler les informations relatives à une localité,
+ * telles que l'identifiant, le nom, la description et le code postal.
+ */
 class Locality {
+    /**
+     * Identifiant unique de la localité.
+     * @var string
+     */
     public $uid;
+
+    /**
+     * Nom de la localité.
+     * @var string
+     */
     public $name;
+
+    /**
+     * Description de la localité.
+     * @var string
+     */
     public $description;
 
+    /**
+     * Code postal de la localité.
+     * @var string
+     */
+    public $postalcode;
+
+    /**
+     * Constructeur de la classe Locality.
+     *
+     * @param object $locality Objet contenant les informations de la localité.
+     */
     public function __construct($locality) {
         $this->uid = $locality->uid;
         $this->name = $locality->name;
         $this->description  = $this->_get_description($locality->description);
+        $this->postalcode = $locality->postalcode;
     }
 
     /**
-     * Get the description of the locality
-     * @param string $item Description renvoyé par $locality->description
-     * @return string
+     * Récupère la description de la localité.
+     *
+     * @param string $item Description renvoyée par $locality->description.
+     * @return string Description formatée en majuscules.
      */
     private function _get_description($item) : string {
         if (is_array($item)) $item = $item[0];

--- a/plugins/mel_cal_resources/mel_cal_resources.php
+++ b/plugins/mel_cal_resources/mel_cal_resources.php
@@ -59,8 +59,9 @@ class mel_cal_resources extends bnum_plugin {
      */
     private function _set_global_env() : void {
         $user = $this->get_user();
-        $user->load(['locality']);
+        $user->load(['locality', 'postalcode']);
         $this->rc()->output->set_env('user_location', $user->locality);
+        $this->rc()->output->set_env('user_postalcode', $user->postalcode);
         $this->rc()->output->set_env('lang', $this->rc()->get_user_language());
     }
 


### PR DESCRIPTION
>Lorsque l'utilisateur ouvre la popup de réservation de ressources il vaudrait mieux faire le lien avec la ville à partir de son code postal plutôt que le nom de ville, car le nom est souvent faux
