### PR TITLE
revert  #211 - 0008403 - :rewind: Revert "Modification du code pour éviter la création d'étiquette sans nom + message d'erreur pour informer les utilisateurs"

### DIFF
--- a/plugins/mel_labels_sync/mel_labels_sync.php
+++ b/plugins/mel_labels_sync/mel_labels_sync.php
@@ -655,18 +655,6 @@ class mel_labels_sync extends rcube_plugin
       $_post_colors = (array) rcube_utils::get_input_value('_colors', rcube_utils::INPUT_POST);
       $old_labels = $this->driver->get_user_labels($this->_get_current_user_name());
 
-      // Détecter les étiquettes vides 
-      $empty_labels = array_filter($_post_labels, function ($name) {
-        return is_string($name) && trim($name) !== '';
-      });
-
-      // Si rien à sauvegarder générer un message d'erreur
-      if (empty($empty_labels)) {
-        $this->rc->output->command('display_message', $this->gettext('empty_label_error'), 'error');
-        $p['abort'] = true; // Empêche le message de succès par défaut
-        return $p;
-      }
-
       // Parcours des labels retournés par le post
       foreach ($_post_labels as $key => $label_name) {
         $old_label = Driver::find_label_by_key($key, $old_labels);


### PR DESCRIPTION
Suppression de la vérification des étiquettes vides.

(revert  #211)