### PR TITLE
0008555 - ♿️ Les options rapides avec des images ne sont pas séléctionnable au clavier.

### DIFF
--- a/plugins/mel_metapage/js/functions.js
+++ b/plugins/mel_metapage/js/functions.js
@@ -3440,6 +3440,23 @@ function save_option(_option_name, _option_value, element, reload = false) {
   );
 }
 
+/**
+ *
+ * @param {HTMLLabelElement} label
+ * @param {KeyboardEvent} event
+ */
+function key_option(label, event) {
+  switch (event.key) {
+    case ' ':
+    case 'Enter':
+      label.parentElement.querySelector('input').click();
+      break;
+
+    default:
+      break;
+  }
+}
+
 //0007910: Popup d'information lors du clic sur un lien dans un mail
 function external_link_modal(_url, isSuspect = false) {
   let url = new URL(_url);

--- a/plugins/mel_metapage/skins/mel_elastic/templates/options/bureau.html
+++ b/plugins/mel_metapage/skins/mel_elastic/templates/options/bureau.html
@@ -6,7 +6,7 @@
         <div class="col-4 text-center px-1">
           <input data-command="updateScollBarMode" type="radio" name="mel-scrollbar-size" id="mel-scrollbar-size-default" data-value="<roundcube:label name='mel_metapage.default' />"
             onclick="save_option('mel-scrollbar-size', rcmail.gettext('default', 'mel_metapage'), this)">
-          <label for="mel-scrollbar-size-default" class="option">
+          <label for="mel-scrollbar-size-default" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image scrollbar_default"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -15,7 +15,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="updateScollBarMode" name="mel-scrollbar-size" id="mel-scrollbar-size-normal" data-value="<roundcube:label name='mel_metapage.normal'/>"
             onclick="save_option('mel-scrollbar-size', rcmail.gettext('normal', 'mel_metapage'), this)">
-          <label for="mel-scrollbar-size-normal" class="option">
+          <label for="mel-scrollbar-size-normal" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image scrollbar_normal"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -24,7 +24,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="updateScollBarMode" name="mel-scrollbar-size" id="mel-scrollbar-size-large" data-value="<roundcube:label name='mel_metapage.large'/>"
             onclick="save_option('mel-scrollbar-size', rcmail.gettext('large', 'mel_metapage'), this)">
-          <label for="mel-scrollbar-size-large" class="option">
+          <label for="mel-scrollbar-size-large" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image scrollbar_large"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -46,7 +46,7 @@
         <div class="col-6 text-center px-1">
           <input data-command="updateMainNavDep" type="radio" name="main_nav_can_deploy" id="deploy-nav-default" data-value="true"
             onclick="save_option('main_nav_can_deploy', true, this)">
-          <label for="deploy-nav-default" class="option">
+          <label for="deploy-nav-default" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image candeploy"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -55,7 +55,7 @@
         <div class="col-6 text-center px-1">
           <input data-command="updateMainNavDep" type="radio" name="main_nav_can_deploy" id="deploy-nav-no" data-value="false"
             onclick="save_option('main_nav_can_deploy', false, this)">
-          <label for="deploy-nav-no" class="option">
+          <label for="deploy-nav-no" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image cannotdeploy"></div>
           </label>
           <div class="switch-overlay"></div>

--- a/plugins/mel_metapage/skins/mel_elastic/templates/options/bureau.html
+++ b/plugins/mel_metapage/skins/mel_elastic/templates/options/bureau.html
@@ -1,35 +1,4 @@
 <div class="container">
-  <!-- <div class="row">
-    <div class="col-12">
-      <div class="options-custom-title">
-        <roundcube:label name='mel_elastic.mel-text-size' />
-      </div>
-      <div class="option_radio_wrapper">
-        <div class="col-6 text-center px-1">
-          <input type="radio" data-command="set_font_size" name="custom-font-size" id="custom-font-size-default" data-value="lg"
-            onclick="save_option('custom-font-size', 'lg', this)">
-          <label for="custom-font-size-default" class="option">
-            <span class="material-symbols-outlined icon-large color-icon">
-              text_fields
-            </span>
-          </label>
-          <div class="switch-overlay"></div>
-          <roundcube:label name="mel_elastic.normal"/>
-        </div>
-        <div class="col-6 text-center px-1">
-          <input type="radio" data-command="set_font_size" name="custom-font-size" id="custom-font-size-smaller" data-value="sm"
-            onclick="save_option('custom-font-size', 'sm', this)">
-          <label for="custom-font-size-smaller" class="option">
-            <span class="material-symbols-outlined icon-small color-icon">
-              text_fields
-            </span>
-          </label>
-          <div class="switch-overlay"></div>
-          <roundcube:label name="mel_elastic.smaller"/>
-        </div>
-      </div>
-    </div>
-  </div> -->
   <div class="row row-options">
     <div class="col-12">
       <div class="options-custom-title"><roundcube:label name='mel_metapage.mel-scrollbar-size' /></div>

--- a/plugins/mel_metapage/skins/mel_elastic/templates/options/mail.html
+++ b/plugins/mel_metapage/skins/mel_elastic/templates/options/mail.html
@@ -64,7 +64,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-message-space" id="mel-message-space-larger" data-value="Plus grand"
             onclick="save_option('mel-message-space', rcmail.gettext('mel_metapage.larger'), this)">
-          <label for="mel-message-space-larger" class="option">
+          <label for="mel-message-space-larger" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image mails_large"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -74,7 +74,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-message-space" id="mel-message-space-normal" data-value="Normal"
             onclick="save_option('mel-message-space', rcmail.gettext('mel_metapage.normal'), this)">
-          <label for="mel-message-space-normal" class="option">
+          <label for="mel-message-space-normal" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image mails_medium"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -84,7 +84,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-message-space" id="mel-message-space-smaller" data-value="Plus petit"
             onclick="save_option('mel-message-space', rcmail.gettext('mel_metapage.smaller'), this)">
-          <label for="mel-message-space-smaller" class="option">
+          <label for="mel-message-space-smaller" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image mails_small"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -102,7 +102,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-folder-space" id="mel-folder-space-larger" data-value="Plus grand"
             onclick="save_option('mel-folder-space', rcmail.gettext('mel_metapage.larger'), this)">
-          <label for="mel-folder-space-larger" class="option">
+          <label for="mel-folder-space-larger" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image folder_large"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -112,7 +112,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-folder-space" id="mel-folder-space-normal" data-value="Normal"
             onclick="save_option('mel-folder-space', rcmail.gettext('mel_metapage.normal'), this)">
-          <label for="mel-folder-space-normal" class="option">
+          <label for="mel-folder-space-normal" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image folder_medium"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -122,7 +122,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-folder-space" id="mel-folder-space-smaller" data-value="Plus petit"
             onclick="save_option('mel-folder-space', rcmail.gettext('mel_metapage.smaller'), this)">
-          <label for="mel-folder-space-smaller" class="option">
+          <label for="mel-folder-space-smaller" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image folder_small"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -140,7 +140,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" name="mailboxes_display" id="mel_mailboxes_display-default" data-value="default"
             onclick="save_option('mailboxes_display', 'default', this)">
-          <label for="mel_mailboxes_display-default" class="option">
+          <label for="mel_mailboxes_display-default" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image grouping_default"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -150,7 +150,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" name="mailboxes_display" id="mel_mailboxes_display-subfolders" data-value="subfolders"
             onclick="save_option('mailboxes_display', 'subfolders', this)">
-          <label for="mel_mailboxes_display-subfolders" class="option">
+          <label for="mel_mailboxes_display-subfolders" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image grouping_grouped"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -160,7 +160,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" name="mailboxes_display" id="mel_mailboxes_display-unified" data-value="unified"
             onclick="save_option('mailboxes_display', 'unified', this)">
-          <label for="mel_mailboxes_display-unified" class="option">
+          <label for="mel_mailboxes_display-unified" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <div class="option-image grouping_unified"></div>
           </label>
           <div class="switch-overlay"></div>
@@ -178,7 +178,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="refresh_messages_list" name="mel_messages_list_clear_headers" id="mel-clear-headers-full" data-value="full"
             onclick="save_option('mel_messages_list_clear_headers', 'full', this)">
-          <label for="mel-clear-headers-full" class="option">
+          <label for="mel-clear-headers-full" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <span class="material-symbols-outlined icon-large color-icon">
               subject
             </span>
@@ -190,7 +190,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="refresh_messages_list" name="mel_messages_list_clear_headers" id="mel-clear-headers-service" data-value="service"
             onclick="save_option('mel_messages_list_clear_headers', 'service', this)">
-          <label for="mel-clear-headers-service" class="option">
+          <label for="mel-clear-headers-service" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <span class="material-symbols-outlined icon-large color-icon">
               notes
             </span>
@@ -202,7 +202,7 @@
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="refresh_messages_list" name="mel_messages_list_clear_headers" id="mel-clear-headers-name" data-value="name"
             onclick="save_option('mel_messages_list_clear_headers', 'name', this)">
-          <label for="mel-clear-headers-name" class="option">
+          <label for="mel-clear-headers-name" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <span class="material-symbols-outlined icon-large color-icon">
               short_text
             </span>
@@ -222,7 +222,7 @@
         <div class="col-6 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-icon-size" id="mel-icon-size-default" data-value="Normal"
             onclick="save_option('mel-icon-size', rcmail.gettext('mel_metapage.normal'), this)">
-          <label for="mel-icon-size-default" class="option">
+          <label for="mel-icon-size-default" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <span class="material-symbols-outlined icon-large color-icon">
               border_color
             </span>
@@ -234,7 +234,7 @@
         <div class="col-6 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-icon-size" id="mel-icon-size-smaller" data-value="Plus petit"
             onclick="save_option('mel-icon-size', rcmail.gettext('mel_metapage.smaller'), this)">
-          <label for="mel-icon-size-smaller" class="option">
+          <label for="mel-icon-size-smaller" class="option" onkeydown="key_option(this, event)" tabindex="0">
             <span class="material-symbols-outlined icon-small color-icon">
               border_color
             </span>

--- a/plugins/mel_metapage/skins/mel_elastic/templates/options/mail.html
+++ b/plugins/mel_metapage/skins/mel_elastic/templates/options/mail.html
@@ -1,10 +1,12 @@
 <div class="container">
+  <!-- Titre principal des options de messagerie -->
   <div class="row mt-4">
     <div class="col-12">
       <div class="options-custom-title"><roundcube:label name='mail' /></div>
       <hr>
     </div>
   </div>
+  <!-- Option : ouvrir les courriels dans une nouvelle fenêtre -->
   <div class="row">
     <div class="col-12 d-flex justify-content-between align-items-center mt-2">
       <div class="d-flex justify-content-center align-items-center">
@@ -22,6 +24,7 @@
       </div>
     </div>
   </div>
+  <!-- Option : composer dans une nouvelle fenêtre -->
   <div class="row">
     <div class="col-12 d-flex justify-content-between align-items-center mt-2">
       <div class="d-flex justify-content-center align-items-center">
@@ -36,25 +39,28 @@
       </div>
     </div>
   </div>
+  <!-- Option : délai d'envoi des messages -->
   <div class="row" <delay_enabled/>>
-  <div class="col-12 justify-content-between mt-2">
-    <div class="d-flex options-custom-title">
-      <roundcube:label name='mel_metapage.delay_speed' />
-      <span class="material-symbols-outlined options-help ml-2" title="<roundcube:label name='mel_metapage.delay_setting_help' />">
-        help
-      </span>
-      <label class="sr-only" for="speed-delay"><roundcube:label name='mel_metapage.delay_setting_help' /></label>
-    </div>
-    <div class="custom-control custom-switch no-click-focus d-flex">
-      <delay/>
-      <p style="margin:0;align-self: center;" class="col-5" id="delay-number"><delay_start/> secondes</p>
+    <div class="col-12 justify-content-between mt-2">
+      <div class="d-flex options-custom-title">
+        <roundcube:label name='mel_metapage.delay_speed' />
+        <span class="material-symbols-outlined options-help ml-2" title="<roundcube:label name='mel_metapage.delay_setting_help' />">
+          help
+        </span>
+        <label class="sr-only" for="speed-delay"><roundcube:label name='mel_metapage.delay_setting_help' /></label>
+      </div>
+      <div class="custom-control custom-switch no-click-focus d-flex">
+        <delay/>
+        <p style="margin:0;align-self: center;" class="col-5" id="delay-number"><delay_start/> secondes</p>
+      </div>
     </div>
   </div>
-</div>
+  <!-- Option : espacement des messages -->
   <div class="row mt-3">
     <div class="col-12">
       <div class="options-custom-title"><roundcube:label name="mel_metapage.mel-message-space-nomail"/></div>
       <div class="option_radio_wrapper">
+        <!-- Plus grand -->
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-message-space" id="mel-message-space-larger" data-value="Plus grand"
             onclick="save_option('mel-message-space', rcmail.gettext('mel_metapage.larger'), this)">
@@ -64,6 +70,7 @@
           <div class="switch-overlay"></div>
           <roundcube:label name='mel_metapage.larger' />
         </div>
+        <!-- Normal -->
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-message-space" id="mel-message-space-normal" data-value="Normal"
             onclick="save_option('mel-message-space', rcmail.gettext('mel_metapage.normal'), this)">
@@ -73,6 +80,7 @@
           <div class="switch-overlay"></div>
           <roundcube:label name='mel_metapage.normal' />
         </div>
+        <!-- Plus petit -->
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-message-space" id="mel-message-space-smaller" data-value="Plus petit"
             onclick="save_option('mel-message-space', rcmail.gettext('mel_metapage.smaller'), this)">
@@ -85,10 +93,12 @@
       </div>
     </div>
   </div>
+  <!-- Option : espacement des dossiers -->
   <div class="row row-options">
     <div class="col-12">
       <div class="options-custom-title"><roundcube:label name="mel_metapage.mel-folder-space-nomail"/></div>
       <div class="option_radio_wrapper">
+        <!-- Plus grand -->
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-folder-space" id="mel-folder-space-larger" data-value="Plus grand"
             onclick="save_option('mel-folder-space', rcmail.gettext('mel_metapage.larger'), this)">
@@ -98,6 +108,7 @@
           <div class="switch-overlay"></div>
           <roundcube:label name='mel_metapage.larger' />
         </div>
+        <!-- Normal -->
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-folder-space" id="mel-folder-space-normal" data-value="Normal"
             onclick="save_option('mel-folder-space', rcmail.gettext('mel_metapage.normal'), this)">
@@ -107,6 +118,7 @@
           <div class="switch-overlay"></div>
           <roundcube:label name='mel_metapage.normal' />
         </div>
+        <!-- Plus petit -->
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-folder-space" id="mel-folder-space-smaller" data-value="Plus petit"
             onclick="save_option('mel-folder-space', rcmail.gettext('mel_metapage.smaller'), this)">
@@ -119,10 +131,12 @@
       </div>
     </div>
   </div>
+  <!-- Option : affichage des dossiers (groupement) -->
   <div class="row row-options">
     <div class="col-12">
       <div class="options-custom-title"><roundcube:label name='mel_metapage.mel-folder-grouping' /></div>
       <div class="option_radio_wrapper">
+        <!-- Affichage par défaut -->
         <div class="col-4 text-center px-1">
           <input type="radio" name="mailboxes_display" id="mel_mailboxes_display-default" data-value="default"
             onclick="save_option('mailboxes_display', 'default', this)">
@@ -132,6 +146,7 @@
           <div class="switch-overlay"></div>
           <roundcube:label name='mel_metapage.default' />
         </div>
+        <!-- Affichage par sous-dossiers -->
         <div class="col-4 text-center px-1">
           <input type="radio" name="mailboxes_display" id="mel_mailboxes_display-subfolders" data-value="subfolders"
             onclick="save_option('mailboxes_display', 'subfolders', this)">
@@ -141,6 +156,7 @@
           <div class="switch-overlay"></div>
           <roundcube:label name='mel.subfolders_pref_text' />
         </div>
+        <!-- Affichage unifié -->
         <div class="col-4 text-center px-1">
           <input type="radio" name="mailboxes_display" id="mel_mailboxes_display-unified" data-value="unified"
             onclick="save_option('mailboxes_display', 'unified', this)">
@@ -153,10 +169,12 @@
       </div>
     </div>
   </div>
+  <!-- Option : affichage des en-têtes des messages -->
   <div class="row row-options">
     <div class="col-12">
       <div class="options-custom-title"><roundcube:label name='mel_metapage.mel-clear-headers' /></div>
       <div class="option_radio_wrapper">
+        <!-- En-tête complet -->
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="refresh_messages_list" name="mel_messages_list_clear_headers" id="mel-clear-headers-full" data-value="full"
             onclick="save_option('mel_messages_list_clear_headers', 'full', this)">
@@ -168,6 +186,7 @@
           <div class="switch-overlay"></div>
           <roundcube:label name='mel_metapage.full' />
         </div>
+        <!-- En-tête service -->
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="refresh_messages_list" name="mel_messages_list_clear_headers" id="mel-clear-headers-service" data-value="service"
             onclick="save_option('mel_messages_list_clear_headers', 'service', this)">
@@ -179,6 +198,7 @@
           <div class="switch-overlay"></div>
           <roundcube:label name='mel_metapage.service' />
         </div>
+        <!-- En-tête nom -->
         <div class="col-4 text-center px-1">
           <input type="radio" data-command="refresh_messages_list" name="mel_messages_list_clear_headers" id="mel-clear-headers-name" data-value="name"
             onclick="save_option('mel_messages_list_clear_headers', 'name', this)">
@@ -193,10 +213,12 @@
       </div>
     </div>
   </div>
+  <!-- Option : taille des icônes -->
   <div class="row row-options">
     <div class="col-12">
       <div class="options-custom-title"><roundcube:label name='mel_metapage.mel-icon-size-nomail' /></div>
       <div class="option_radio_wrapper">
+        <!-- Taille normale -->
         <div class="col-6 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-icon-size" id="mel-icon-size-default" data-value="Normal"
             onclick="save_option('mel-icon-size', rcmail.gettext('mel_metapage.normal'), this)">
@@ -208,6 +230,7 @@
           <div class="switch-overlay"></div>
           <roundcube:label name='mel_metapage.normal' />
         </div>
+        <!-- Plus petit -->
         <div class="col-6 text-center px-1">
           <input type="radio" data-command="update_mail_css" name="mel-icon-size" id="mel-icon-size-smaller" data-value="Plus petit"
             onclick="save_option('mel-icon-size', rcmail.gettext('mel_metapage.smaller'), this)">


### PR DESCRIPTION
>Au clavier, les options rapide tel que "Deplier la barre de navigation" ne sont pas séléctionnable au clavier.

<img width="392" height="363" alt="image" src="https://github.com/user-attachments/assets/aaf870cd-836f-4dde-bdd9-9b41d8415705" />
Ces options n'étaient pas sélectionnable au clavier.