### PR TITLE
0008764 - ✨ forcer le refresh quand un article est créé

### DIFF
--- a/plugins/mel_forum/js/lib/forum.js
+++ b/plugins/mel_forum/js/lib/forum.js
@@ -7,6 +7,7 @@ import { MelTemplate } from '../../../mel_metapage/js/lib/html/JsHtml/MelTemplat
 import { MelHtml } from '../../../mel_metapage/js/lib/html/JsHtml/MelHtml.js';
 import { CursorUtils } from '../../../mel_metapage/js/lib/helpers/cursorUtils.js';
 import { formatPostDate } from './utils.js';
+import { Refresh } from './refresh.js';
 
 export class Forum extends MelObject {
   constructor() {
@@ -33,6 +34,10 @@ export class Forum extends MelObject {
     this.initButtons();
     this.initSortSelect();
     this.initPostDisplay();
+
+    if (!window._refreshInstance) {
+    window._refreshInstance = new Refresh();
+  }
   }
 
   /**

--- a/plugins/mel_forum/js/lib/refresh.js
+++ b/plugins/mel_forum/js/lib/refresh.js
@@ -1,0 +1,172 @@
+import { MelObject } from '../../../mel_metapage/js/lib/mel_object.js';
+import { MelTemplate } from '../../../mel_metapage/js/lib/html/JsHtml/MelTemplate.js';
+
+export class Refresh extends MelObject {
+  constructor() {
+    super();
+    this.dismissedCount = null;
+  }
+
+  /**
+   * Intialise les variables
+   */
+  main() {
+    super.main();
+    this.workspace = this.get_env('workspace_uid')
+    this.seenCount = parseInt(this.get_env('post_seen_count')) || 0;
+    this.currentCount = parseInt(this.get_env('post_new_count')) || 0;
+    
+    // Refresh basé sur celui du BNUM
+    this.rcmail().addEventListener('mel_metapage_refresh', () => {
+      this.checkPostCount();
+    });
+  }
+
+  /**
+   * Vérifie si de nouveaux posts sont disponibles
+   */
+  checkPostCount() {
+    console.log('[REFRESH] Vérification de nouveaux posts...');
+    console.trace('[REFRESH] post_seen_count (session):', this.seenCount);
+
+    this.http_internal_post({
+      task: 'forum',
+      action: 'count_posts',
+      params: {
+        _workspace_uid: this.workspace,
+      },
+      on_success: (response) => {
+        try {
+          const data = JSON.parse(response);
+          const latestCount = parseInt(data.count);
+
+          const diff = latestCount - this.seenCount;
+
+          if (diff > 0) {
+            // Nouveaux articles
+            if (this.dismissedCount === latestCount) {
+              console.log('[REFRESH] Banniere déjà ignorée pour ce count :', latestCount);
+              return;
+            }
+
+            console.log('[REFRESH] Nouveaux articles détectés:', diff);
+            if (window.ForumRefreshBanner) ForumRefreshBanner.remove();
+            this.displayBanner(diff, latestCount);
+
+          } else if (diff < 0) {
+            // Suppressions détectées
+            const deletedCount = -diff;
+            const dismissId = `d${latestCount}`;
+
+            if (this.dismissedCount === dismissId) {
+              console.log('[REFRESH] Bannière suppression déjà ignorée pour ce count :', dismissId);
+              return;
+            }
+
+            console.log('[REFRESH] Articles supprimés détectés :', deletedCount);
+            if (window.ForumRefreshBanner) ForumRefreshBanner.remove();
+            this.displayBanner(deletedCount, latestCount, true); // <--- true = suppression
+
+          } else {
+            console.log('[REFRESH] Aucun changement');
+          }
+
+        } catch (e) {
+          console.error("Erreur JSON.parse:", e);
+        }
+      }
+    });
+  }
+
+  /**
+   * Met à jour le compteur vu côté serveur
+   */
+  updateSeenPostCount(count) {
+    this.http_internal_post({
+      task: 'forum',
+      action: 'update_seen_post_count',
+      params : {
+        _workspace_uid: this.workspace,
+        _count: count
+      },
+      on_success: () => {
+        this.seenCount = count;
+        console.log("[REFRESH] Compteur vu mis à jour avec succès, rechargement...");
+        window.location.reload();
+      }
+    });
+  }
+
+  /**
+   * Ferme la bannière et met à jour le compteur sans rechargement
+   */
+  dismissBanner(count = null) {
+    if (window.ForumRefreshBanner) {
+      ForumRefreshBanner.remove();
+      window.ForumRefreshBanner = null;
+    }
+
+    if (count !== null) {
+      this.dismissedCount = count;
+      console.log('[REFRESH] Banniere fermée — dismissedCount =', count);
+    }
+  }
+
+  /**
+   * Crée la bannière d'information
+   */
+  displayBanner(diff, newCount, isDeleted = false) {
+    const templateElement = document.querySelector('#forum_refresh_banner_template');
+    if (!templateElement) {
+      console.warn('[BANNER] Template non trouvé dans le DOM');
+      return;
+    }
+
+    const message = diff === 1
+      ? `1 ${rcmail.gettext(isDeleted ? 'mel_forum.deleted_single_post' : 'mel_forum.new_single_post_available')}`
+      : `${diff} ${rcmail.gettext(isDeleted ? 'mel_forum.deleted_multiple_post' : 'mel_forum.new_multiple_post_available')}`;
+
+    const data = { MESSAGE: message };
+
+    const dismissId = isDeleted ? `d${newCount}` : newCount;
+
+    const template = new MelTemplate()
+      .setTemplateSelector('#forum_refresh_banner_template')
+      .setData(data)
+      .addEvent(
+        '.refresh-btn',
+        'click',
+        this.updateSeenPostCount.bind(this, newCount),
+      )
+      .addEvent(
+        '.refresh-btn',
+        'keydown',
+        (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            this.updateSeenPostCount(newCount);
+          }
+        },
+      )
+      .addEvent(
+        '.dismiss-btn',
+        'click',
+        this.dismissBanner.bind(this, dismissId),
+      )
+      .addEvent(
+        '.dismiss-btn',
+        'keydown',
+        (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            this.dismissBanner(dismissId);
+          }
+        },
+      );
+
+    $('#banner-area').empty();
+    $('#banner-area').append(...template.render());
+
+    window.ForumRefreshBanner = document.querySelector('#banner-area .forum-refresh-banner');
+  }
+}

--- a/plugins/mel_forum/js/lib/refresh.js
+++ b/plugins/mel_forum/js/lib/refresh.js
@@ -1,5 +1,6 @@
 import { MelObject } from '../../../mel_metapage/js/lib/mel_object.js';
 import { MelTemplate } from '../../../mel_metapage/js/lib/html/JsHtml/MelTemplate.js';
+import { BnumLog } from '../../../mel_metapage/js/lib/classes/bnum_log.js';
 
 export class Refresh extends MelObject {
   constructor() {
@@ -26,8 +27,8 @@ export class Refresh extends MelObject {
    * Vérifie si de nouveaux posts sont disponibles
    */
   checkPostCount() {
-    console.log('[REFRESH] Vérification de nouveaux posts...');
-    console.trace('[REFRESH] post_seen_count (session):', this.seenCount);
+    BnumLog.info('[REFRESH] Vérification de nouveaux posts...');
+    BnumLog.debug('[REFRESH] post_seen_count (session):', this.seenCount);
 
     this.http_internal_post({
       task: 'forum',
@@ -45,11 +46,11 @@ export class Refresh extends MelObject {
           if (diff > 0) {
             // Nouveaux articles
             if (this.dismissedCount === latestCount) {
-              console.log('[REFRESH] Banniere déjà ignorée pour ce count :', latestCount);
+              BnumLog.info('[REFRESH] Banniere déjà ignorée pour ce count :', latestCount);
               return;
             }
 
-            console.log('[REFRESH] Nouveaux articles détectés:', diff);
+            BnumLog.info('[REFRESH] Nouveaux articles détectés:', diff);
             if (window.ForumRefreshBanner) ForumRefreshBanner.remove();
             this.displayBanner(diff, latestCount);
 
@@ -59,20 +60,20 @@ export class Refresh extends MelObject {
             const dismissId = `d${latestCount}`;
 
             if (this.dismissedCount === dismissId) {
-              console.log('[REFRESH] Bannière suppression déjà ignorée pour ce count :', dismissId);
+              BnumLog.info('[REFRESH] Bannière suppression déjà ignorée pour ce count :', dismissId);
               return;
             }
 
-            console.log('[REFRESH] Articles supprimés détectés :', deletedCount);
+            BnumLog.info('[REFRESH] Articles supprimés détectés :', deletedCount);
             if (window.ForumRefreshBanner) ForumRefreshBanner.remove();
             this.displayBanner(deletedCount, latestCount, true); // <--- true = suppression
 
           } else {
-            console.log('[REFRESH] Aucun changement');
+            BnumLog.info('[REFRESH] Aucun changement');
           }
 
         } catch (e) {
-          console.error("Erreur JSON.parse:", e);
+          BnumLog.error("Erreur JSON.parse:", e);
         }
       }
     });
@@ -91,7 +92,7 @@ export class Refresh extends MelObject {
       },
       on_success: () => {
         this.seenCount = count;
-        console.log("[REFRESH] Compteur vu mis à jour avec succès, rechargement...");
+        BnumLog.info("[REFRESH] Compteur vu mis à jour avec succès, rechargement...");
         window.location.reload();
       }
     });
@@ -108,7 +109,7 @@ export class Refresh extends MelObject {
 
     if (count !== null) {
       this.dismissedCount = count;
-      console.log('[REFRESH] Banniere fermée — dismissedCount =', count);
+      BnumLog.info('[REFRESH] Banniere fermée — dismissedCount =', count);
     }
   }
 
@@ -118,7 +119,7 @@ export class Refresh extends MelObject {
   displayBanner(diff, newCount, isDeleted = false) {
     const templateElement = document.querySelector('#forum_refresh_banner_template');
     if (!templateElement) {
-      console.warn('[BANNER] Template non trouvé dans le DOM');
+      BnumLog.warning('[BANNER] Template non trouvé dans le DOM');
       return;
     }
 
@@ -164,8 +165,9 @@ export class Refresh extends MelObject {
         },
       );
 
-    $('#banner-area').empty();
-    $('#banner-area').append(...template.render());
+    const bannerArea = document.getElementById('banner-area');
+    bannerArea.innerHTML = '';
+    bannerArea.append(...template.render());
 
     window.ForumRefreshBanner = document.querySelector('#banner-area .forum-refresh-banner');
   }

--- a/plugins/mel_forum/localization/fr_FR.inc
+++ b/plugins/mel_forum/localization/fr_FR.inc
@@ -292,3 +292,11 @@ $labels['settings'] = 'paramètres';
 $labels['the'] = 'Le';
 $labels['at_modify'] = 'a modifié';
 $labels['return_to_post'] = 'Retour à l\'article';
+
+#region Refresh
+$labels['refresh_button'] = 'Rafraîchir';
+$labels['dismiss_button'] = 'Fermer';
+$labels['new_single_post_available'] = 'nouvel article est disponible !';
+$labels['new_multiple_post_available'] = 'nouveaux articles sont disponibles !';
+$labels['deleted_single_post'] = 'article a été supprimé !';
+$labels['deleted_multiple_post'] = 'articles ont été supprimés !';

--- a/plugins/mel_forum/mel_forum.php
+++ b/plugins/mel_forum/mel_forum.php
@@ -101,6 +101,9 @@ class mel_forum extends bnum_plugin
                 $this->register_action('download_article', [$this, 'download_article']);
                 // Affichage de l'historique d'un post
                 $this->register_action('history', [$this, 'history']);
+                $this->register_action('count_posts', [$this, 'count_posts']);
+                $this->register_action('update_seen_post_count', [$this, 'update_seen_post_count']);
+
 
                 $this->register_action('create_zip_with_md_and_images', [$this, 'create_zip_with_md_and_images']);
             } else if (!$this->rc()->action === 'load_image') {
@@ -679,15 +682,39 @@ class mel_forum extends bnum_plugin
     }
 
     /**
-     * Met dans l'env roundcube une liste de post.
+     * Affiche les publications dans l'interface Roundcube pour un espace de travail donné.
      *
-     * Cette fonction récupère toutes les publications d'un espace de travail, 
-     * formate chaque publication avec ses détails (créateur, date, titre, résumé, image, tags, 
-     * et nombre de réactions et commentaires) et génère le HTML correspondant.
+     * Cette méthode récupère les publications d’un espace de travail spécifique, les formate
+     * et les transmet à l’environnement Roundcube pour affichage côté client.
+     * Elle initialise également les compteurs nécessaires pour suivre le nombre total de publications
+     * et le nombre de publications déjà vues par l’utilisateur.
+     *
+     * Fonctionnement :
+     * - Récupère l'identifiant de l’espace de travail depuis les paramètres de requête.
+     * - Génère les données des publications au format JSON et les envoie à l’environnement JavaScript.
+     * - Calcule le nombre total de publications dans l’espace de travail.
+     * - Stocke, si nécessaire, le nombre de publications vues dans la session utilisateur.
+     * - Met à jour l’environnement Roundcube avec les compteurs "total" et "vu".
+     *
+     * @return void
      */
     protected function _show_posts()
     {
+        $workspace_uid = rcube_utils::get_input_value('_workspace_uid', rcube_utils::INPUT_GPC);
+        
         $this->rc()->output->set_env('posts_data', $this->_post_object_to_JSON(null, self::POST_DEFAULT_LIMIT, true));
+
+        // Compteur total actuel d’articles publiés
+        $count = $this->_get_post_count_internal($workspace_uid);
+
+        // Compteur vu stocké dans la session utilisateur
+        if (!isset($_SESSION["forum_seen_count_{$workspace_uid}"])) {
+            $_SESSION["forum_seen_count_{$workspace_uid}"] = $count;
+        }
+        $seen = $_SESSION["forum_seen_count_{$workspace_uid}"];
+
+        $this->rc()->output->set_env('post_new_count', $count); // compteur total actuel
+        $this->rc()->output->set_env('post_seen_count', $seen); // compteur "vu" stocké pour l’utilisateur
     }
 
     /**
@@ -700,6 +727,112 @@ class mel_forum extends bnum_plugin
         $pin = $this->get_input('_pin', rcube_utils::INPUT_GET) === "true";
         echo json_encode($this->_post_object_to_JSON(null, $limit ?? self::POST_DEFAULT_LIMIT, $pin));
         exit;
+    }
+
+    /**
+     * Compte le nombre de publications publiées dans un espace de travail.
+     *
+     * Cette méthode récupère l'identifiant de l'espace de travail à partir des paramètres de requête,
+     * puis utilise l'API interne pour filtrer et compter les publications qui ne sont pas des brouillons
+     * (i.e., qui sont publiées) et qui ont un titre non vide.
+     *
+     * Fonctionnement :
+     * - Initialise un objet de publication avec l’UID de l’espace de travail.
+     * - Définit les filtres pour exclure les brouillons et les publications sans titre.
+     * - Utilise les opérateurs de filtre définis dans la configuration de l’API.
+     * - Récupère le nombre de publications correspondant à ces critères.
+     * - Retourne ce nombre au format JSON puis termine l’exécution du script.
+     *
+     * @return void
+     */
+    public function count_posts()
+    {
+        $workspace_uid = rcube_utils::get_input_value('_workspace_uid', rcube_utils::INPUT_GPC);
+
+        // Initialiser le post et ses filtres
+        $post = new \LibMelanie\Api\Defaut\Posts\Post();
+        $post->workspace = $workspace_uid;
+
+        $post->isdraft = true;
+        $post->title = '';
+
+        $operators = [
+            'workspace' => \LibMelanie\Config\MappingMce::eq,
+            'title'     => \LibMelanie\Config\MappingMce::diff,
+            'isdraft'   => \LibMelanie\Config\MappingMce::diff,
+        ];
+
+        $result = $post->getList('count', "", $operators);
+        $count = isset($result[0]->count) ? (int) $result[0]->count : 0;
+
+        echo json_encode(['count' => $count]);
+        exit;
+    }
+
+    /**
+     * Met à jour le compteur de publications vues par l'utilisateur dans un espace de travail.
+     *
+     * Cette méthode reçoit en POST l'identifiant de l’espace de travail ainsi que le nouveau
+     * compteur de publications vues. Elle enregistre cette valeur dans la session utilisateur,
+     * puis répond avec un statut JSON.
+     *
+     * Fonctionnement :
+     * - Récupère l’UID de l’espace de travail et le compteur depuis les données POST.
+     * - Si les données sont valides, met à jour le compteur dans la session PHP.
+     * - Ferme explicitement la session pour s'assurer que la donnée est bien enregistrée.
+     * - Retourne une réponse JSON indiquant le succès ou l’échec de l’opération.
+     *
+     * @return void
+     */
+    public function update_seen_post_count()
+    {
+        $workspace_uid = rcube_utils::get_input_value('_workspace_uid', rcube_utils::INPUT_POST);
+        $count = (int) rcube_utils::get_input_value('_count', rcube_utils::INPUT_POST);
+
+        if ($workspace_uid && $count > 0) {
+            $_SESSION["forum_seen_count_{$workspace_uid}"] = $count;
+            session_write_close(); // Forcer php à écrire la session.
+            echo json_encode(['status' => 'success']);
+            exit;
+        }
+
+        echo json_encode(['status' => 'error', 'message' => 'Missing data']);
+        exit;
+    }
+
+    /**
+     * Récupère le nombre de publications publiées pour un espace de travail donné.
+     *
+     * Cette méthode initialise un objet de type Post avec l'identifiant de l’espace de travail
+     * et applique des filtres pour exclure les brouillons et les publications sans titre. Elle interroge ensuite
+     * l'API pour obtenir le nombre total de publications correspondant à ces critères.
+     *
+     * Fonctionnement :
+     * - Initialise un objet Post lié à l’espace de travail spécifié.
+     * - Applique les filtres suivants :
+     *     - Le titre ne doit pas être vide.
+     *     - La publication ne doit pas être un brouillon.
+     * - Exécute la requête de comptage via l’API interne.
+     * - Retourne le nombre obtenu, ou 0 si aucune donnée n'est disponible.
+     *
+     * @param string $workspace_uid L'identifiant de l’espace de travail.
+     * @return int Le nombre de publications publiées (hors brouillons et titres vides).
+     */
+    protected function _get_post_count_internal($workspace_uid) 
+    {
+        $post = new \LibMelanie\Api\Defaut\Posts\Post();
+        $post->workspace = $workspace_uid;
+        $post->isdraft = true;
+        $post->title = '';
+
+        $operators = [
+            'workspace' => \LibMelanie\Config\MappingMce::eq,
+            'title'     => \LibMelanie\Config\MappingMce::diff,
+            'isdraft'   => \LibMelanie\Config\MappingMce::diff,
+        ];
+
+        $result = $post->getList('count', "", $operators);
+        return isset($result[0]->count) ? (int) $result[0]->count : 0;
     }
 
     #endregion
@@ -2210,7 +2343,7 @@ class mel_forum extends bnum_plugin
      */
     function refresh($args)
     {
-        return array('abort' => true);
+        return [];
     }
 
     #region Téléchargements

--- a/plugins/mel_forum/skins/mel_elastic/less/mel_forum.less
+++ b/plugins/mel_forum/skins/mel_elastic/less/mel_forum.less
@@ -1527,3 +1527,88 @@
 #history-list li {
   margin-bottom: 10px; /* Ajuste cette valeur selon tes préférences */
 }
+
+.forum-refresh-banner.custom-banner {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1050;
+  width: 600px;
+  padding: 12px 40px;
+  margin: 0 auto;
+
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+
+  background-color: #FFFFFF;
+  color: var(--main-text-color);
+
+  .banner-message {
+    margin: 0;
+    font-weight: 500;
+    color: inherit;
+  }
+
+  .banner-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    .btn {
+      font-weight: 500;
+      border-radius: 6px;
+      padding: 6px 12px;
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  // Mode sombre
+  .dark-mode &,
+  .dark-mode-custom & {
+    background-color: #42414D;
+    color: var(--main-text-color);
+
+    .banner-message {
+      color: inherit;
+    }
+  }
+
+  // Petits écrans : texte au-dessus, boutons côte à côte
+  @media (max-width: 600px) {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+    padding: 16px;
+
+    .banner-message {
+      margin-bottom: 12px;
+    }
+
+    .banner-actions {
+      flex-direction: row;
+      justify-content: center;
+      flex-wrap: nowrap;
+      gap: 8px;
+    }
+  }
+
+  // Moyens et grands écrans : bannière plus large
+  @media (min-width: 768px) {
+    max-width: 1000px;
+    padding: 12px 40px;
+  }
+}
+
+
+
+
+
+
+

--- a/plugins/mel_forum/skins/mel_elastic/mel_forum.css
+++ b/plugins/mel_forum/skins/mel_elastic/mel_forum.css
@@ -1318,3 +1318,70 @@
   margin-bottom: 10px;
   /* Ajuste cette valeur selon tes préférences */
 }
+.forum-refresh-banner.custom-banner {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1050;
+  width: 600px;
+  padding: 12px 40px;
+  margin: 0 auto;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  background-color: #FFFFFF;
+  color: var(--main-text-color);
+}
+.forum-refresh-banner.custom-banner .banner-message {
+  margin: 0;
+  font-weight: 500;
+  color: inherit;
+}
+.forum-refresh-banner.custom-banner .banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.forum-refresh-banner.custom-banner .banner-actions .btn {
+  font-weight: 500;
+  border-radius: 6px;
+  padding: 6px 12px;
+  display: flex;
+  align-items: center;
+}
+.dark-mode .forum-refresh-banner.custom-banner,
+.dark-mode-custom .forum-refresh-banner.custom-banner {
+  background-color: #42414D;
+  color: var(--main-text-color);
+}
+.dark-mode .forum-refresh-banner.custom-banner .banner-message,
+.dark-mode-custom .forum-refresh-banner.custom-banner .banner-message {
+  color: inherit;
+}
+@media (max-width: 600px) {
+  .forum-refresh-banner.custom-banner {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+    padding: 16px;
+  }
+  .forum-refresh-banner.custom-banner .banner-message {
+    margin-bottom: 12px;
+  }
+  .forum-refresh-banner.custom-banner .banner-actions {
+    flex-direction: row;
+    justify-content: center;
+    flex-wrap: nowrap;
+    gap: 8px;
+  }
+}
+@media (min-width: 768px) {
+  .forum-refresh-banner.custom-banner {
+    max-width: 1000px;
+    padding: 12px 40px;
+  }
+}

--- a/plugins/mel_forum/skins/mel_elastic/templates/forum.html
+++ b/plugins/mel_forum/skins/mel_elastic/templates/forum.html
@@ -4,6 +4,9 @@
   <roundcube:label name="mel_forum" />
 </h1>
 
+<!-- Conteneur pour la bannière -->
+<div id="banner-area"></div>
+
 <div id="layout-content" role="main">
   <div class="content">
     <div class="row return-header d-flex justify-content-between mb-3">
@@ -224,6 +227,24 @@
 <template id="tag_template">
   <span class="tag tag-clickable tag-%%TAG_ID%%" data-tag-id="%%TAG_ID%%" tabindex="0" role="button"
     aria-label="Tag %%TAG_NAME%%">%%TAG_NAME%%</span>
+</template>
+
+<template id="forum_refresh_banner_template">
+  <div class="forum-refresh-banner custom-banner d-flex justify-content-between align-items-center p-3">
+    <span class="banner-message mb-0">
+      %%MESSAGE%%
+    </span>
+    <div class="banner-actions ml-3 d-flex">
+      <!-- Rafraîchir -->
+      <primary-button class="refresh-btn" data-icon="refresh" data-icon-pos="right" square>
+        <roundcube:label name="mel_forum.refresh_button" />
+      </primary-button>
+      <!-- Fermer -->
+      <secondary-button class="dismiss-btn" data-icon="close" data-icon-pos="right" square>
+        <roundcube:label name="mel_forum.dismiss_button" />
+      </secondary-button>
+    </div>
+  </div>
 </template>
 
 <roundcube:include file="includes/footer.html" />


### PR DESCRIPTION
Lorsqu'un nouvel article est publié par un utilisateur, les autres utilisateurs voient une bannière s'afficher, ils ont alors la possibilité de rafraichir leur page pour voir apparaitre dans la liste des articles le nouvel article ou de fermer la bannière sans rafraichir leur page.

La bannière est responsive et dynamique et permet donc d'afficher si plusieurs articles ont été publié ou supprimé.

