### PR TITLE
0008627 - 🐛 - Skin dark: Filtre les boutons supprimer / ajouter et options avancées color est sombre et limite ils sont non visibles

### DIFF
--- a/plugins/roundrive/skins/elastic/style.css
+++ b/plugins/roundrive/skins/elastic/style.css
@@ -395,6 +395,11 @@ table.propform td.source table.propform td {
   background-color: inherit;
 }
 
+/* Modification pour affichage correcte des icônes en mode sombre */
+.propform td.rowbuttons a::before {
+  color: var(--main-text-color);
+}
+
 .auth-options {
   margin-top: 5px;
 }


### PR DESCRIPTION
Les icones n'apparaissaient pas en mode sombre. Modification du CSS pour affichage correct des icônes.