### PR TITLE
0009167: 🐛  Proposer deux urls Pégase : page web et clic sur un lien

### DIFF
--- a/plugins/mel_metapage/js/init/events.js
+++ b/plugins/mel_metapage/js/init/events.js
@@ -2705,10 +2705,15 @@ function sendMessageToAriane(data) {
     'https://rcube.preprod.m2.e2.rie.gouv.fr',
   ];
 
-  const pegaze_url =
+  const pegase_url =
     rcmail.env.sondage_url ||
     parent.rcmail.env.sondage_url ||
     top.rcmail.env.sondage_url;
+
+  const pegase_email_url = 
+    rcmail.env.sondage_email_url ||
+    parent.rcmail.env.sondage_email_url ||
+    top.rcmail.env.sondage_email_url;
 
   const suggestionUrl = 'suggestionUrl'; //type/value
   const suggestionId = 'suggestionId';
@@ -2736,7 +2741,7 @@ function sendMessageToAriane(data) {
         //Url au clique
         let link = event.data[datas_url_accepted];
 
-        if (link.includes(pegaze_url))
+        if (link.includes(pegase_url) || link.includes(pegase_email_url))
           link = mel_metapage.Functions.url('sondage', null, { _url: link });
 
         $('<a>')

--- a/plugins/mel_sondage/mel_sondage.php
+++ b/plugins/mel_sondage/mel_sondage.php
@@ -54,6 +54,7 @@ class mel_sondage extends rcube_plugin
     	}
         
         $rcmail->output->set_env('sondage_url', $sondage_url);
+        $rcmail->output->set_env('sondage_email_url', $rcmail->config->get('sondage_email_url', $sondage_url));
         
         if (class_exists("mel_metapage")) mel_metapage::add_url_spied($sondage_url, 'sondage');
         // Ajoute le bouton en fonction de la skin


### PR DESCRIPTION
Fix MANTIS 0009167

Ajouter une nouvelle url pour sondage qui correspond à l'url envoyée par email qui peut être différente de l'url de sondage configuré dans le Bnum. Pouvoir intercepter les deux url indifféremment