### PR TITLE
0008403 : 🐛 - Tabulation: boutons resync et enlever non accessible avec le clavier

### DIFF
--- a/plugins/mel_moncompte/statistiques/mobile.php
+++ b/plugins/mel_moncompte/statistiques/mobile.php
@@ -305,7 +305,14 @@ class Mobile_Stats
                         ));
 
                         $table = $this->rc->table_output($attrib_device, $result, $a_show_cols, 'id');
-                        // Ajoute scope="col" aux <th> si absent
+
+                        // Accessibilité : focus clavier sur la table + légende + scope="col" sur th si absent
+                        $table = preg_replace('/<table\b(?![^>]*\btabindex=)/i', '<table tabindex="0"', $table, 1);
+                        if (stripos($table, '<caption') === false) {
+                            $cap = htmlspecialchars($this->plugin->gettext('device_info'), ENT_QUOTES, 'UTF-8');
+                            $table = preg_replace('/<table\b[^>]*>/i', '$0<caption id="rcmdeviceinfo-caption">'.$cap.'</caption>', $table, 1);
+                        }
+
                         $table = preg_replace('/<th\b(?![^>]*\bscope=)/i', '<th scope="col" ', $table);
 
                         // Wrapper focusable (scroll clavier) + focus visible sans CSS global
@@ -343,6 +350,14 @@ class Mobile_Stats
                             ));
 
                             $table = $this->rc->table_output($attrib_as, $result, $a_show_cols, 'id');
+
+                            // Accessibilité : focus clavier sur la table + légende + scope="col" sur th si absent
+                            $table = preg_replace('/<table\b(?![^>]*\btabindex=)/i', '<table tabindex="0"', $table, 1);
+                            if (stripos($table, '<caption') === false) {
+                                $cap = htmlspecialchars($this->plugin->gettext('activesync_info'), ENT_QUOTES, 'UTF-8');
+                                $table = preg_replace('/<table\b[^>]*>/i', '$0<caption id="rcmactivesyncinfo-caption">'.$cap.'</caption>', $table, 1);
+                            }
+
                             $table = preg_replace('/<th\b(?![^>]*\bscope=)/i', '<th scope="col" ', $table);
 
                             $out .= html::div([
@@ -396,6 +411,13 @@ class Mobile_Stats
                 $attrib_accounts['escape'] = false; // autoriser le HTML des boutons
 
                 $table = $this->rc->table_output($attrib_accounts, $result_accounts, $a_show_cols_accounts, 'id');
+
+                // Accessibilité : focus clavier sur la table + légende + scope="col" sur th si absent
+                $table = preg_replace('/<table\b(?![^>]*\btabindex=)/i', '<table tabindex="0"', $table, 1);
+                if (stripos($table, '<caption') === false) {
+                    $cap = htmlspecialchars($this->plugin->gettext('accounts_list'), ENT_QUOTES, 'UTF-8');
+                    $table = preg_replace('/<table\b[^>]*>/i', '$0<caption id="rcmaccountsinfo-caption">'.$cap.'</caption>', $table, 1);
+                }
                 $table = preg_replace('/<th\b(?![^>]*\bscope=)/i', '<th scope="col" ', $table);
 
                 $out .= html::div([
@@ -493,6 +515,13 @@ class Mobile_Stats
                 $attrib_table['escape'] = false;
 
                 $table = $this->rc->table_output($attrib_table, $result, $a_show_cols, 'id');
+
+                // Accessibilité : focus clavier sur la table + légende + scope="col" sur th si absent
+                $table = preg_replace('/<table\b(?![^>]*\btabindex=)/i', '<table tabindex="0"', $table, 1);
+                if (stripos($table, '<caption') === false) {
+                    $cap = htmlspecialchars($this->plugin->gettext('sync_details'), ENT_QUOTES, 'UTF-8');
+                    $table = preg_replace('/<table\b[^>]*>/i', '$0<caption id="rcmsyncdetails-caption">'.$cap.'</caption>', $table, 1);
+                }
                 $table = preg_replace('/<th\b(?![^>]*\bscope=)/i', '<th scope="col" ', $table);
 
                 $out .= html::div([

--- a/plugins/mel_moncompte/statistiques/mobile.php
+++ b/plugins/mel_moncompte/statistiques/mobile.php
@@ -274,7 +274,10 @@ class Mobile_Stats
                         $wiperequestedon = (isset($device['wiperequestedon']) ? date('r', $device['wiperequestedon']) : "");
                         $wipeactionon = (isset($device['wipeactionon']) ? date('r', $device['wipeactionon']) : "");
 
-                        $attrib['id'] = 'rcmdeviceinfo';
+                        // Table 1 : Informations sur l'appareil
+                        $attrib_device = $attrib;
+                        $attrib_device['id'] = 'rcmdeviceinfo';
+                        $attrib_device['escape'] = false; 
 
                         // define list of cols to be displayed
                         $a_show_cols = array(
@@ -301,12 +304,24 @@ class Mobile_Stats
                             'class' => '',
                         ));
 
-                        $out .= html::div(null, $this->plugin->gettext('device_info'));
-                        // create XHTML table
-                        $out .= $this->rc->table_output($attrib, $result, $a_show_cols, 'id');
+                        $table = $this->rc->table_output($attrib_device, $result, $a_show_cols, 'id');
+                        // Ajoute scope="col" aux <th> si absent
+                        $table = preg_replace('/<th\b(?![^>]*\bscope=)/i', '<th scope="col" ', $table);
 
+                        // Wrapper focusable (scroll clavier) + focus visible sans CSS global
+                        $out .= html::div([
+                            'tabindex' => '0',
+                            'role' => 'region',
+                            'aria-label' => $this->plugin->gettext('device_info'),
+                            'onfocus' => "this.style.outline='2px solid';this.style.outlineOffset='2px'",
+                            'onblur' => "this.style.outline='';this.style.outlineOffset=''",
+                        ], $table);
+
+                        // Table 2 : Informations sur ActiveSync
                         if ($versionzpush >= 2) {
-                            $attrib['id'] = 'rcmactivesyncinfo';
+                            $attrib_as = $attrib;
+                            $attrib_as['id'] = 'rcmactivesyncinfo';
+                            $attrib_as['escape']= false;
 
                             // define list of cols to be displayed
                             $a_show_cols = array(
@@ -327,9 +342,16 @@ class Mobile_Stats
                                 'class' => '',
                             ));
 
-                            $out .= html::div(null, $this->plugin->gettext('activesync_info'));
-                            // create XHTML table
-                            $out .= $this->rc->table_output($attrib, $result, $a_show_cols, 'id');
+                            $table = $this->rc->table_output($attrib_as, $result, $a_show_cols, 'id');
+                            $table = preg_replace('/<th\b(?![^>]*\bscope=)/i', '<th scope="col" ', $table);
+
+                            $out .= html::div([
+                                'tabindex' => '0',
+                                'role' => 'region',
+                                'aria-label' => $this->plugin->gettext('activesync_info'),
+                                'onfocus' => "this.style.outline='2px solid';this.style.outlineOffset='2px'",
+                                'onblur' => "this.style.outline='';this.style.outlineOffset=''",
+                            ], $table);
                         }
 
                         $one = false;
@@ -340,34 +362,49 @@ class Mobile_Stats
                     $lastsync = date('D d M y H:i:s', $device['lastupdatetime']);
                     $maxzpushvers = $device['zpushversion'];
 
+                    // Bouton Resync
+                    $btn_resync = html::tag('button', [
+                        'type' => 'button',
+                        'class' => 'button resync icon-btn',
+                        'aria-label' => $this->plugin->gettext('device_resync') . ' ' . $userDevice,
+                        'onclick' => "zpush_command('ResyncUserDevice', '$deviceId', '$userDevice')",
+                    ], $this->plugin->gettext('device_resync'));
+
+                    // Bouton Remove
+                    $btn_remove = html::tag('button', [
+                        'type' => 'button',
+                        'class' => 'button remove icon-btn danger',
+                        'aria-label' => $this->plugin->gettext('device_remove') . ' ' . $userDevice,
+                        'onclick' => "zpush_command('DeleteUserDevice', '$deviceId', '$userDevice')",
+                    ], $this->plugin->gettext('device_remove'));
+
                     $result_accounts[] = array(
                         'id' => 'rcmaccountsinfo--' . $deviceId . '--' . $userDevice,
                         'mel_moncompte.user' => $userDevice,
                         'mel_moncompte.first_sync' => $firstsync,
                         'mel_moncompte.last_sync' => $lastsync,
                         'mel_moncompte.z-push' => $maxzpushvers,
-                        'mel_moncompte.resync' => ['html' => html::tag('button', [
-                            'type' => 'button',
-                            'class' => 'button resync',
-                            'title' => $this->plugin->gettext('device_resync'),
-                            'onclick' => "zpush_command('ResyncUserDevice', '$deviceId', '$userDevice')",
-                            'tabindex' => '0'
-                        ], $this->plugin->gettext('device_resync'))],
-                        'mel_moncompte.remove' => ['html' => html::tag('button', [
-                            'type' => 'button',
-                            'class' => 'button remove',
-                            'title' => $this->plugin->gettext('device_remove'),
-                            'onclick' => "zpush_command('DeleteUserDevice', '$deviceId', '$userDevice')",
-                            'tabindex' => '0'
-                        ], $this->plugin->gettext('device_remove'))],
+                        'mel_moncompte.resync' => ['html' => $btn_resync],
+                        'mel_moncompte.remove' => ['html' => $btn_remove],
                         'class' => '',
                     );
                 }
 
-                $attrib['id'] = 'rcmaccountsinfo';
-                $out .= html::div(null, $this->plugin->gettext('accounts_list'));
-                // create XHTML table
-                $out .= $this->rc->table_output($attrib, $result_accounts, $a_show_cols_accounts, 'id');
+                // Table 3: Liste des comptes configurés sur l'appareil
+                $attrib_accounts = $attrib;
+                $attrib_accounts['id'] = 'rcmaccountsinfo';
+                $attrib_accounts['escape'] = false; // autoriser le HTML des boutons
+
+                $table = $this->rc->table_output($attrib_accounts, $result_accounts, $a_show_cols_accounts, 'id');
+                $table = preg_replace('/<th\b(?![^>]*\bscope=)/i', '<th scope="col" ', $table);
+
+                $out .= html::div([
+                    'tabindex' => '0',
+                    'role' => 'region',
+                    'aria-label' => $this->plugin->gettext('accounts_list'),
+                    'onfocus' => "this.style.outline='2px solid';this.style.outlineOffset='2px'",
+                    'onblur' => "this.style.outline='';this.style.outlineOffset=''",
+                ], $table);
             }
         } catch (Exception $ex) {
             mel_logs::get_instance()->log(mel_logs::ERROR, "[mobiles_list] " . $ex->getTraceAsString());
@@ -429,6 +466,14 @@ class Mobile_Stats
                             $id_folderid = str_replace('.', '_-p-_', $id_folderid);
                             $id_userFolder = str_replace('.', '_-p-_', $userFolder);
 
+                            // Bouton Resync avec aria-label spécifique
+                            $btn_resync = html::tag('button', [
+                                'type' => 'button',
+                                'class' => 'button resync icon-btn',
+                                'aria-label' => $this->plugin->gettext('device_resync') . ' : ' . $userFolder . ' (' . $type . ')',
+                                'onclick' => "zpush_command('ResyncFolderId', '$deviceId', '$id_userFolder', '$id_folderid')",
+                            ], $this->plugin->gettext('device_resync'));
+
                             $result[] = array(
                                 'id' => 'rcmsyncdetails--' . $deviceId . '--' . $id_userFolder . '--' . $id_folderid,
                                 'mel_moncompte.mailbox' => $userFolder,
@@ -436,22 +481,27 @@ class Mobile_Stats
                                 'mel_moncompte.foldersync' => $folderidname,
                                 'mel_moncompte.last_sync' => $lastsync,
                                 'mel_moncompte.z-push' => $zpushversion,
-                                'mel_moncompte.resync' => ['html' => html::tag('button', [
-                                    'type' => 'button',
-                                    'class' => 'button resync',
-                                    'title' => $this->plugin->gettext('device_resync'),
-                                    'onclick' => "zpush_command('ResyncFolderId', '$deviceId', '$id_userFolder', '$id_folderid')",
-                                    'tabindex' => '0'
-                                ], $this->plugin->gettext('device_resync'))],
+                                'mel_moncompte.resync' => ['html' => $btn_resync],
                                 'mel_moncompte.remaining' => $synced . " / " . $total,
                             );
                         }
                     }
                 }
 
-                $out .= html::div(null, $this->plugin->gettext('sync_details'));
-                // create XHTML table
-                $out .= $this->rc->table_output($attrib, $result, $a_show_cols, 'id');
+                // rendre la table accessible : escape = false
+                $attrib_table = $attrib;
+                $attrib_table['escape'] = false;
+
+                $table = $this->rc->table_output($attrib_table, $result, $a_show_cols, 'id');
+                $table = preg_replace('/<th\b(?![^>]*\bscope=)/i', '<th scope="col" ', $table);
+
+                $out .= html::div([
+                    'tabindex' => '0',
+                    'role' => 'region',
+                    'aria-label' => $this->plugin->gettext('sync_details'),
+                    'onfocus' => "this.style.outline='2px solid';this.style.outlineOffset='2px'",
+                    'onblur' => "this.style.outline='';this.style.outlineOffset=''",
+                ], $table);
             }
         } catch (Exception $ex) {
             mel_logs::get_instance()->log(mel_logs::ERROR, "[mobiles_list] " . $ex->getTraceAsString());


### PR DESCRIPTION
Nouvelles modifications du code avec ajouts suivants :

Ajout de escape = false, pour rendre les informations accessibles au clavier.
Envelopper chaque table dans une div focusable pour pouvoir faire défiler au clavier.
Ajout d'aria label et annotation des <th> pour les lecteurs d'écran.

+ refactorisation de certaines parties de code pour plus de lisibilité.

A tester une nouvelle fois en recette car non testable en dev.