### PR TITLE
0009225: Améliorer les performances des espaces de travail

### DIFF
--- a/plugins/mel_metapage/js/lib/html/JsHtml/CustomAttributes/avatar.js
+++ b/plugins/mel_metapage/js/lib/html/JsHtml/CustomAttributes/avatar.js
@@ -476,10 +476,7 @@ class AvatarElement extends HtmlCustomTag {
     if (this.saved) return this._on_load();
 
     let url = AVATAR_URL.replace('%0', this._email);
-
-    if (this._errorBackgroundColor)
-      url += `&_background=${this._errorBackgroundColor.replaceAll('#', EMPTY_STRING)}`;
-
+    
     this.setAttribute('data-state', 'loading');
     let img = this.navigator.querySelector('img');
     img.onload = this._on_load.bind(this);

--- a/plugins/mel_workspace/lib/NavBar.php
+++ b/plugins/mel_workspace/lib/NavBar.php
@@ -155,9 +155,13 @@ class NavBar {
     $this->css[] = file_get_contents($file);
   }
 
-  public function get() {
+  public function get($workspace = null) {
     include_once __DIR__.'/Workspace.php';
-    $workspace = new Workspace($this->uid, true);
+
+    if (!isset($workspace)) {
+      $workspace = new Workspace($this->uid, true);
+    }
+
     // $picture = mel_workspace::GetWorkspaceLogo($workspace->get());
     // $description = str_replace('"', "''", $workspace->description());
     // $title = $workspace->title();

--- a/plugins/mel_workspace/mel_workspace.php
+++ b/plugins/mel_workspace/mel_workspace.php
@@ -321,7 +321,7 @@ class mel_workspace extends bnum_plugin
             $navbar->add_css(__DIR__ . '/' . $this->local_skin_path() . '/navbar.css');
             $navbar->add_css(__DIR__ . '/../../' . $this->local_skin_path() . '/material-symbols.css');
 
-            $this->set_env('navbar', $navbar->get());
+            $this->set_env('navbar', $navbar->get($this->workspace));
 
             self::IncludeNavBarComponent();
 
@@ -2043,7 +2043,15 @@ class mel_workspace extends bnum_plugin
 
     public static function Workspace($uid): Workspace
     {
-        return Workspace::GetLoad($uid);
+        if (!is_array(self::$_workspaces)) {
+            self::$_workspaces = [];
+        }
+
+        if (!isset(self::$_workspaces[$uid])) {
+            self::$_workspaces[$uid] = Workspace::GetLoad($uid);
+        }
+
+        return self::$_workspaces[$uid];
     }
 
     private static function _CurrentUser()


### PR DESCRIPTION
- Mettre en cache les avatar en n'utilisant plus le background color dans l'url (perte de cache)
- Ne charger le workspace qu'une seule fois en l'utilisant aussi dans la NavBar, sinon toutes les données sont chargés deux fois