### PR TITLE
0009198 - :sparkles: Activer la visioconférence dés que l'on ajoute un participant

### DIFF
--- a/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.js
@@ -972,6 +972,11 @@ export class GuestsPart extends FakePart {
 
       this.update_free_busy();
 
+      // Mettre à jour la localisation
+      if ($('#edit-location').val() === EMPTY_STRING) {
+        $('.event-location-select').first().val('visio').change();
+      }
+
       return true;
     }
 

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/location_part.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/location_part.js
@@ -1575,11 +1575,14 @@ export class LocationPartManager extends IDestroyable {
    * @package
    */
   _on_select_changed(event) {
-    const VISIBLE = '';
+    const VISIBLE = EMPTY_STRING;
 
     let $select = $(event.target);
     const id = $select.data('id');
-    const val = $select.val() || '';
+    const val = $select.val() || EMPTY_STRING;
+
+    // Si la valeur est vide, on ne fait rien
+    if (val === EMPTY_STRING) return;
 
     //On cache toutes les locations
     $(`#location-${id}-container .location-mode`)


### PR DESCRIPTION
>Pour faire comme "teams", faire en sorte que dés qu'on ajoute un participant à un événement, passer de "Présentiel" à "En visioconférence" le mode d'événement