### PR TITLE
0009198 - ✨ Activer la visioconférence dés que l'on ajoute un participant (Correctif)

### DIFF
--- a/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/guestspart.js
@@ -973,7 +973,11 @@ export class GuestsPart extends FakePart {
       this.update_free_busy();
 
       // Mettre à jour la localisation
-      if ($('#edit-location').val() === EMPTY_STRING) {
+      if (
+        $('.event-location-select').length === 1 &&
+        $('.event-location-select').val() === 'location' &&
+        $('#edit-location').val() === EMPTY_STRING
+      ) {
         $('.event-location-select').first().val('visio').change();
       }
 


### PR DESCRIPTION
>Pour faire comme "teams", faire en sorte que dés qu'on ajoute un participant à un événement, passer de "Présentiel" à "En visioconférence" le mode d'événement

Ajout de la comptabilité avec les ressources.