### PR TITLE
0009201 - 🐛 Bloquer la réservation d'une même ressource sur deux

### DIFF
--- a/plugins/mel_cal_resources/js/add_resources.js
+++ b/plugins/mel_cal_resources/js/add_resources.js
@@ -444,9 +444,14 @@ class ResourceDialog extends MelObject {
 
         if (
           page._functions
-            .search(page.start, page.end, {
-              id: current_resource.email,
-            })
+            .search(
+              page.start,
+              page.end,
+              {
+                id: current_resource.email,
+              },
+              { includesNonPlainDate: true },
+            )
             .count() > 0
         ) {
           BnumMessage.DisplayMessage(

--- a/plugins/mel_cal_resources/js/add_resources.js
+++ b/plugins/mel_cal_resources/js/add_resources.js
@@ -183,10 +183,56 @@ class ResourceDialog extends MelObject {
   }
 
   /**
+   * Démarre un chargement.
+   *
+   * On passe par un tableau pour gérer les chargements imbriqués.
+   */
+  startLoading() {
+    this._loading ??= [];
+    this._loading.push(false);
+
+    let save = document.querySelector('.ui-dialog-buttonset .save-btn');
+    if (
+      save &&
+      (this._loading.length === 1 || save.hasAttribute('disabled') === false)
+    ) {
+      if (!this._mid)
+        this._mid = BnumMessage.DisplayMessage('Chargement...', 'loading');
+
+      save.setAttribute('disabled', 'disabled');
+      save.classList.add('disabled');
+    }
+
+    save = null;
+  }
+
+  /**
+   * Fini un chargement.
+   * @returns {void}
+   */
+  stopLoading() {
+    this._loading.pop();
+    if (this._loading.length > 0) return;
+
+    BnumMessage.ClearMessage(this._mid);
+    this._mid = undefined;
+    this._loading = undefined;
+
+    let save = document.querySelector('.ui-dialog-buttonset .save-btn');
+
+    if (save) {
+      save.removeAttribute('disabled');
+      save.classList.remove('disabled');
+    }
+    save = null;
+  }
+
+  /**
    *
    * @returns
    */
   async _init() {
+    this.export('rscdialog');
     let page;
     let resources = [];
 
@@ -394,6 +440,22 @@ class ResourceDialog extends MelObject {
             eMessageType.Error,
           );
           return page.set_validity();
+        }
+
+        if (
+          page._functions
+            .search(page.start, page.end, {
+              id: current_resource.email,
+            })
+            .count() > 0
+        ) {
+          BnumMessage.DisplayMessage(
+            // eslint-disable-next-line quotes
+            'Vous réservez une ressource déjà utilisée à cette date !',
+            eMessageType.Error,
+          );
+
+          return false;
         }
       }
 

--- a/plugins/mel_cal_resources/js/lib/resources_functions.js
+++ b/plugins/mel_cal_resources/js/lib/resources_functions.js
@@ -354,15 +354,16 @@ class ResourceBaseFunctions {
    */
   resource_render(resourceObj, labelTds) {
     if (resourceObj.id !== 'resources') {
-
       const city = resourceObj.data.locality;
-      const locatedText = MelObject.Empty().gettext('resource_located_at', 'mel_cal_resources');
+      const locatedText = MelObject.Empty().gettext(
+        'resource_located_at',
+        'mel_cal_resources',
+      );
       const cityText = MelObject.Empty().gettext('city', 'mel_cal_resources');
 
       // Mise en place d'un title
       if (city) {
-        labelTds.find('.fc-cell-text')
-          .attr('title', `${locatedText} ${city}`);
+        labelTds.find('.fc-cell-text').attr('title', `${locatedText} ${city}`);
       }
 
       labelTds
@@ -370,13 +371,13 @@ class ResourceBaseFunctions {
         .addClass('cfc-resource')
         .append(this._functions.resource_render_element(resourceObj.data));
 
-        // Accessibilité : aria-label sur l’input type="radio"
+      // Accessibilité : aria-label sur l’input type="radio"
       if (city) {
         const node = labelTds.find('bnum-resource-selector').get(0);
 
         const accessibleNameOnRadioInput = () => {
           const radioInput = node?.querySelector('input[id^="radio-"]');
-          
+
           const resourceLabel =
             labelTds.find('label.fc-cell-text, .fc-cell-text').get(0) ||
             node?.querySelector('label.fc-cell-text');
@@ -384,8 +385,11 @@ class ResourceBaseFunctions {
           if (radioInput && resourceLabel) {
             const visibleLabelText = (resourceLabel.textContent || '').trim();
             // Ex. "Bureau Bureau 139 Place 1 ville : L’Isle d’Abeau"
-            radioInput.setAttribute('aria-label', `${visibleLabelText} ${cityText} ${city}`);
-            
+            radioInput.setAttribute(
+              'aria-label',
+              `${visibleLabelText} ${cityText} ${city}`,
+            );
+
             return true;
           }
           return false;
@@ -433,6 +437,9 @@ class ResourceBaseFunctions {
    */
   async event_loader_async(start, end, timezone, callback) {
     const key = `${start.format()}-${end.format()}`;
+    //rscdialog est défini dans add_resources.js
+    //Il s'agit de la modale et permet 'accéder directement à celle-ci.
+    window.rscdialog.startLoading();
 
     let emails = this._p_resources
       .map((x) => x.data.email)
@@ -478,6 +485,8 @@ class ResourceBaseFunctions {
         this._$calendar.fullCalendar('refetchEvents');
       }, 100);
     }
+
+    window.rscdialog.stopLoading();
   }
 
   /**


### PR DESCRIPTION
>A priori on peut encore réserver une même ressource si les deux créneaux ne sont pas identiques, il faudrait totalement bloquer cette possibilité

Si il y avait du lag dans le chargement des free-busy, on pouvait quand même réserver une ressource.
Actuellement, il y a une vérification à la sauvegarde