### PR TITLE
0008546 - 🐛 Pister les liens sortant du Bnum même si l'usager utilise le clic-molette

### DIFF
--- a/plugins/mel_metapage/js/init/events.js
+++ b/plugins/mel_metapage/js/init/events.js
@@ -2681,6 +2681,13 @@ $(document).ready(() => {
     intercept_click(event);
   });
 
+  // Mantis 0008546 : Interception du clic molette
+  $(document).on('auxclick', 'a', (event) => {
+    if (event.button === 1) {
+      intercept_click(event);
+    }
+  });
+
   rcmail.addEventListener('event.click', (params) => {
     intercept_click(params.e === undefined ? params.obj : params.e);
   });


### PR DESCRIPTION
Modification du code JS pour prise en compte du clic molette lors de l'ouverture de la modale, lorsqu'un lien suspect est détecté dans un e-mail