### PR TITLE
recette - 0009233 - :bug: La création d'un évènement n'ajoute pas le bon organisateur

### DIFF
--- a/plugins/mel_workspace/js/lib/program/addons/calendar/calendar_additions.js
+++ b/plugins/mel_workspace/js/lib/program/addons/calendar/calendar_additions.js
@@ -258,10 +258,22 @@ class CalendarAddition extends WorkspaceObject {
         );
         const organizer = MelEnumerable.from(
           calendarEvent.attendees,
-        ).firstOrDefault((x) => x.role === 'ORGANIZER');
+        ).firstOrDefault(null, (x) => x.role === 'ORGANIZER');
 
-        if (organizer) data.attendees.push(organizer);
-        else
+        if (organizer) {
+          if (
+            MelEnumerable.from(data.attendees).any(
+              (x) => x.email === organizer.email,
+            )
+          ) {
+            data.attendees = data.attendees.map((x) => {
+              if (x.email === organizer.email) {
+                x.role = 'ORGANIZER';
+              }
+              return x;
+            });
+          } else data.attendees.push(organizer);
+        } else
           data.attendees.push({
             name: MelCurrentUser.fullname,
             email: MelCurrentUser.email,


### PR DESCRIPTION
- L'organisateur ajouté n'était pas forcément le bon
Ce qui pouvait faire un doublon dans les participants et toujours avoir des évènements sans organisateurs.