### PR TITLE
0009244 - :clown_face: Modifier un évènement avec un lien VRoom fausse l'emplacement.

### DIFF
--- a/plugins/mel_cal_resources/js/lib/resource_location.js
+++ b/plugins/mel_cal_resources/js/lib/resource_location.js
@@ -415,6 +415,7 @@ class ResourceLocation extends AExternalLocationPart {
           tmp.resource_type = key;
           tmp.cutype = iterator.cutype;
           tmp.rcs_labels = iterator.labels;
+          tmp.initBeforeInternal = iterator.initBeforeInternal;
           tmp.OptionValue = function () {
             return this.resource_type;
           }.bind(tmp);
@@ -438,6 +439,9 @@ class ResourceLocation extends AExternalLocationPart {
                 .toArray();
             } else return [];
           }.bind(tmp);
+          tmp.InitBeforeInternal = function () {
+            return this.initBeforeInternal;
+          };
           tmp.Max = ResourceLocation.Max.bind(tmp);
           eval(`tmp.prototype.resource_type = () => '${key}'`);
           LocationPartManager.AddExtraLocationType(tmp);

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/location_part.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/location_part.js
@@ -297,6 +297,15 @@ class AExternalLocationPart extends ALocationPart {
   static PluginName() {
     return 'mel_metapage';
   }
+
+  /**
+   * A initialiser avant la création de la partie
+   * @virtual
+   * @returns {boolean}
+   */
+  static InitBeforeInternal() {
+    return false;
+  }
 }
 
 /**
@@ -1477,8 +1486,23 @@ export class LocationPartManager extends IDestroyable {
    * @param {*} event Evènement du plugin `Calendar`
    */
   init(event) {
+    var tmp;
     let no_location = true;
     this._$locations.html(EMPTY_STRING);
+
+    for (const ExtraPart of MelEnumerable.from(
+      LocationPartManager.FAKE_LOCATION_PART,
+    ).where((x) => x.InitBeforeInternal?.() ?? false)) {
+      if (ExtraPart.Has(event)) {
+        if (no_location) no_location = false;
+
+        tmp = ExtraPart.Instantiate(event);
+
+        for (const tuple of tmp) {
+          this.add(tuple.item1, tuple.item2);
+        }
+      }
+    }
 
     if (event.location?.trim?.() || false) {
       let location = event.location.split(LOCATION_SEPARATOR);
@@ -1495,8 +1519,9 @@ export class LocationPartManager extends IDestroyable {
       }
     }
 
-    let tmp;
-    for (const ExtraPart of LocationPartManager.FAKE_LOCATION_PART) {
+    for (const ExtraPart of MelEnumerable.from(
+      LocationPartManager.FAKE_LOCATION_PART,
+    ).where((x) => !(x.InitBeforeInternal?.() ?? false))) {
       if (ExtraPart.Has(event)) {
         if (no_location) no_location = false;
 


### PR DESCRIPTION
Ba en fait, le correctif orm à déjà tout corriger. 
J'ai juste ajouter des configurations pour permettre aux locations externes de checker avant les internes.

