### PR TITLE
0009287 - :pencil2: Correction d'une faute dans un texte d'erreur

### DIFF
--- a/plugins/mel_metapage/localization/fr_FR.inc
+++ b/plugins/mel_metapage/localization/fr_FR.inc
@@ -481,7 +481,7 @@ $labels['custom_alarm_title'] = 'Alarme personnalisée';
 $labels['validate'] = 'Valider';
 
 $labels['invalid_guests'] = 'Impossible d\'ajouter certains participants !';
-$labels['existing_guest'] = 'Le participant %0 éxiste déjà !';
+$labels['existing_guest'] = 'Le participant %0 existe déjà !';
 
 $labels['add_guests'] = 'Ajoutez des participants';
 $labels['req_guest'] = 'Participants obligatoires';


### PR DESCRIPTION
>Lors de la convertion du mail en évènement, si il y a l'erreur en image, il est écris "éxiste" au lieu de "existe"