### PR TITLE
0009154 - :adhesive_bandage: Restreindre l'usage de l'action Dupliquer aux agendas en écriture

### DIFF
--- a/plugins/calendar/skins/mel_elastic/templates/calendar.html
+++ b/plugins/calendar/skins/mel_elastic/templates/calendar.html
@@ -273,8 +273,8 @@
     <roundcube:button type="link-menuitem" command="event-sendbymail" label="send" class="send disabled"
       classAct="send active" />
     <roundcube:container name="events-options-containers" id="events-options-containers" />
-    <roundcube:button type="link-menuitem" command="event-copy" label="mel_metapage.duplicate" class="copy disabled"
-      classAct="copy active" />
+    <roundcube:button type="link-menuitem" command="event-copy" label="mel_metapage.duplicate" class="duplicate copy disabled"
+      classAct="copy duplicate active" />
     <roundcube:if condition="env:calendar_driver == 'kolab' && config:kolab_bonnie_api" />
     <roundcube:button type="link-menuitem" command="event-history" label="calendar.eventhistory"
       class="history disabled" classAct="history active" />

--- a/plugins/mel_metapage/js/init/events.js
+++ b/plugins/mel_metapage/js/init/events.js
@@ -1607,10 +1607,18 @@ if (rcmail && window.mel_metapage) {
               rcmail.triggerEvent('edit-event', event);
             }),
           );
+
+        $('#eventoptionsmenu .duplicate')
+          .removeClass('hidden')
+          .removeAttr('hidden');
+      } else {
+        $('#eventoptionsmenu .duplicate')
+          .addClass('hidden')
+          .attr('hidden', 'hidden');
       }
 
       //Options
-      if (!datas.temp && !event.temporary && event.calendar != '_resource') {
+      if (!datas.temp && !event.temporary && event.calendar !== '_resource') {
         $('<button>')
           .attr({
             href: '#',


### PR DESCRIPTION
>L'action "Dupliquer" est trop souvent utilisée à contre sens. Cela duplique les participants (c'est voulu, sinon il y a "Copier sans les participants") et cela peut générer des doublons dans les calendrier des participants si la date n'est pas changée.
>Un usage typique de "Dupliquer" est la régénération d'un récurrent en fin de vie.
>La limitation de cette action à l'organisateur initiale serait une réponse, mais cela poserait des soucis dans le cadre des pool agenda (plusieurs organisateurs)
>L'idée retenu a été de limiter l'usage de "Dupliquer" a des évènements provenant d'agenda en lecture et écriture
