### PR TITLE
0008829 - ✨ Faire un message de notification lorsque qu'une redirection Sieve vers l'extérieur est positionnée

### DIFF
--- a/plugins/mel_supervision/localization/fr_FR.inc
+++ b/plugins/mel_supervision/localization/fr_FR.inc
@@ -4,3 +4,4 @@ $labels['mel_supervision'] = 'mel_supervision';
 $labels['mail_warning_subject'] = '[ALERTE] Modification suspecte de l\'identité du compte $email';
 $labels['mail_warning_message_reply-to'] = '"Reply to" dans "Identités et signature" à été défini sur l\'adresse externe : $key';
 $labels['mail_warning_message_bcc'] = '"Cci" dans "Identités et signature" à été défini sur l\'adresse externe : $key';
+$labels['mail_warning_message_sieve_redirect'] = 'Une règle sieve a créé des redirections vers les adresses externe:<br/> $key';

--- a/plugins/mel_supervision/mel_supervision.php
+++ b/plugins/mel_supervision/mel_supervision.php
@@ -61,7 +61,8 @@ class mel_supervision extends bnum_plugin {
     $this->require_plugin(self::REQUIRED_PLUGIN);
     $this->add_hooks(
       [
-        self::HOOK_IDENTITY_UPDATE => [$this, self::CALLBACK_IDENTITY_UPDATE]
+        self::HOOK_IDENTITY_UPDATE => [$this, self::CALLBACK_IDENTITY_UPDATE],
+        'managesieve_save_after' => [$this, 'hook_managesieve_save_after']
       ]
     );
   }
@@ -81,12 +82,48 @@ class mel_supervision extends bnum_plugin {
     $replyto = $args[$RECORD][self::FIELD_TO] ?? EMPTY_STRING;
     $bcc = $args[$RECORD][self::FIELD_BCC] ?? EMPTY_STRING;
 
-    $replyto = $this->get_user_from_email($replyto);
-    $bcc = $this->get_user_from_email($bcc);
+    $uReplyto = $this->get_user_from_email($replyto);
+    $uBcc = $this->get_user_from_email($bcc);
 
-    $this->_sendMessageIfExternal(self::FIELD_TO, $replyto)->_sendMessageIfExternal(self::FIELD_BCC, $bcc);
+    $this->_sendMessageIfExternal(self::FIELD_TO, $uReplyto, true, $replyto)->_sendMessageIfExternal(self::FIELD_BCC, $uBcc, true, $bcc);
 
     return $args;
+  }
+
+  public function hook_managesieve_save_after($_) {
+    $actions_types = rcube_utils::get_input_value('_action_type', rcube_utils::INPUT_POST, true);
+
+    if ($actions_types !== null && is_array($actions_types)) {
+      $act_targets    = rcube_utils::get_input_value('_action_target', rcube_utils::INPUT_POST, true);
+
+      $mails = [];
+
+      foreach ($actions_types as $idx => $type) {
+        switch ($type) {
+          case 'redirect':
+          case 'redirect_copy':
+            $target = $this->strip_value($act_targets[$idx]);
+            $mail = $this->get_user_from_email($target);
+
+            if (!$mail || ($mail && ($mail->is_external || !$mail->exists()))) {
+              $mails[] = $target;
+            }
+
+            break;
+          
+          default:
+            break;
+        }
+      }
+
+      if (!empty($mails)) {
+        $this->_sendMessageIfExternal('sieve_redirect', null, false, implode(', ', $mails));
+      }
+    }
+
+
+
+    return $_;
   }
 
   /**
@@ -95,17 +132,25 @@ class mel_supervision extends bnum_plugin {
    *
    * @param string $key Nom du champ surveillé.
    * @param \LibMelanie\Api\Defaut\User|null $item Utilisateur correspondant à l'adresse.
+   * @param bool $userPref Si on sauvegarde dans les prefs utilisateurs
+   * @param string|null $emails Adresse(s) à utiliser dans le mail (si différente de l'utilisateur ou si $item peut être null)
    * @return self
    */
-  private function _sendMessageIfExternal(string $key, ?\LibMelanie\Api\Defaut\User $item): self {
+  private function _sendMessageIfExternal(string $key, ?\LibMelanie\Api\Defaut\User $item, bool $userPref = true, ?string $emails = null): self {
     $VAR_EMAIL = 'email';
     $VAR_KEY = 'key';
     $IDENTITY_UPDATE = "identity_update_$key";
 
     // On vérifie si l'adresse à changer entre temps
-    $config = $this->get_config($IDENTITY_UPDATE);
+    $config = $userPref ? $this->get_config($IDENTITY_UPDATE) : null;
 
-    if ($item !== null && $config !== $item->email && (!$item->exists() || $item->is_external)) {
+    $hasEmailDefine = $item === null && $emails !== null && $emails !== EMPTY_STRING;
+    $isExternal = $item !== null && (!$item->exists() || $item->is_external);
+    $isChanged = $config !== ($item === null ? $emails : $item->email);
+    $testingEmail = $hasEmailDefine || ($isChanged && $isExternal);
+    // Si on a pas d'email (($item null et $emails non null et non vide) => Pas d'utilisateur mais une adresse a été défini => externe => on rentre dans le if
+    // Si l'eamil a changé et que c'est une adresse externe => externe => on rentre dans le if 
+    if ($testingEmail) {
       // Si c'est le cas, on envoie un mail d'avertissement
       $email = self::MAIL_SENDER;
       $to = $this->get_config(self::CONFIG_MAIL_RECEIVER);
@@ -119,7 +164,7 @@ class mel_supervision extends bnum_plugin {
       $to = explode(',', $to);
 
       $subject = $this->gettext(['name' => self::TEXT_MAIL_SUBJECT, 'vars' => [$VAR_EMAIL => $this->get_user()->uid]]);
-      $message = $this->gettext(['name' => self::TEXT_MAIL_BODY, 'vars' => [$VAR_KEY => $item->email]]);
+      $message = $this->gettext(['name' => self::TEXT_MAIL_BODY."_$key", 'vars' => [$VAR_KEY => $emails ?? $item->email]]);
 
       if ($this->get_config(self::CONFIG_AMEDEE_ADMIN, false)) {
         $admins = mel_helper::SearchOperatorsMelByDn($this->get_user()->uid);
@@ -132,10 +177,43 @@ class mel_supervision extends bnum_plugin {
       if (mel_logs::gi()->is(mel_logs::WARN)) mel_logs::gi()->log(mel_logs::WARN, "Modification de l'adresse $key vers une adresse externe détectée pour l'utilisateur " . $this->rc()->user->get_username());
       
       // On sauvegarde la nouvelle adresse pour eviter de SPAM
-      $this->rc()->user->save_prefs([$IDENTITY_UPDATE => $item->email]);
+      if ($userPref) $this->rc()->user->save_prefs([$IDENTITY_UPDATE => $item === null ? $emails : $item->email]);
     }
-    else if($item !== null) $this->rc()->user->save_prefs([$IDENTITY_UPDATE => EMPTY_STRING]);
+    else if($item !== null && $config !== $item->email && $userPref) $this->rc()->user->save_prefs([$IDENTITY_UPDATE => EMPTY_STRING]);
 
     return $this;
   }
+
+
+      /**
+     * Trims and makes safe an input value
+     *
+     * @param string|array $str        Input value
+     * @param bool         $allow_html Allow HTML tags in the value
+     * @param bool         $trim       Trim the value
+     *
+     * @return string|array
+     */
+    protected function strip_value($str, $allow_html = false, $trim = true)
+    {
+        if (is_array($str)) {
+            foreach ($str as $idx => $val) {
+                $str[$idx] = $this->strip_value($val, $allow_html, $trim);
+
+                if ($str[$idx] === '') {
+                    unset($str[$idx]);
+                }
+            }
+
+            return $str;
+        }
+
+        $str = (string) $str;
+
+        if (!$allow_html) {
+            $str = strip_tags($str);
+        }
+
+        return $trim ? trim($str) : $str;
+    }
 }

--- a/plugins/mel_supervision/mel_supervision.php
+++ b/plugins/mel_supervision/mel_supervision.php
@@ -32,6 +32,10 @@ class mel_supervision extends bnum_plugin {
    */
   const FIELD_BCC = 'bcc';
   /**
+   * Champ "sieve_redirect" surveillé.
+   */
+  const FIELD_SIEVE_REDIRECT = 'sieve_redirect';
+  /**
    * Expéditeur des mails d'avertissement.
    */
   const MAIL_SENDER = 'bnum';
@@ -90,18 +94,33 @@ class mel_supervision extends bnum_plugin {
     return $args;
   }
 
+  /**
+   * Hook appelé après la sauvegarde des règles Sieve.
+   *
+   * @param any[] $_ Arguments du hook.
+   * @return any[]
+   */
   public function hook_managesieve_save_after($_) {
-    $actions_types = rcube_utils::get_input_value('_action_type', rcube_utils::INPUT_POST, true);
+    $INPUT_ACTION_TYPE = '_action_type';
+    $INPUT_ACTION_TARGET = '_action_target';
+    $CASE_REDIRECT = 'redirect';
+    $CASE_REDIRECT_COPY = 'redirect_copy';
+
+    $this->load_config();
+    $this->add_texts(self::FOLDER_LOCALIZATION);
+    $actions_types = rcube_utils::get_input_value($INPUT_ACTION_TYPE, rcube_utils::INPUT_POST, true);
 
     if ($actions_types !== null && is_array($actions_types)) {
-      $act_targets    = rcube_utils::get_input_value('_action_target', rcube_utils::INPUT_POST, true);
+      $act_targets = rcube_utils::get_input_value($INPUT_ACTION_TARGET, rcube_utils::INPUT_POST, true);
 
+      // Les types d'actions et leurs cibles sont tout les deux des tableaux de même tailles,
+      // les indexes correspondent entre les deux tableaux.
       $mails = [];
 
       foreach ($actions_types as $idx => $type) {
         switch ($type) {
-          case 'redirect':
-          case 'redirect_copy':
+          case $CASE_REDIRECT:
+          case $CASE_REDIRECT_COPY:
             $target = $this->strip_value($act_targets[$idx]);
             $mail = $this->get_user_from_email($target);
 
@@ -117,7 +136,7 @@ class mel_supervision extends bnum_plugin {
       }
 
       if (!empty($mails)) {
-        $this->_sendMessageIfExternal('sieve_redirect', null, false, implode(', ', $mails));
+        $this->_sendMessageIfExternal(self::FIELD_SIEVE_REDIRECT, null, false, implode('<br/>', $mails));
       }
     }
 


### PR DESCRIPTION
>Si une redirection Sieve est positionnée vers des adresses "extérieures", il faut envoyer un message d'alerte avec les mêmes destinataires que les messages d'alerte de grillage de comptes

