### PR TITLE
0009297 - :lipstick: Changement du libellé pour l'enregistrement d'une session lors de la connexion

### DIFF
--- a/plugins/mel/localization/fr_FR.inc
+++ b/plugins/mel/localization/fr_FR.inc
@@ -103,8 +103,8 @@ $labels['name identity'] = 'Nom affiché dans le webmail';
 
 $labels['error_block'] = 'Echec de connexion, votre compte est bloqué';
 
-$labels['computer_private'] = 'Enregistrer mes informations d\'identification sur cet ordinateur';
-$labels['device_private'] = 'Enregistrer mes informations d\'identification sur cet ordinateur';
+$labels['computer_private'] = 'Faire confiance à cet ordinateur';
+$labels['device_private'] = 'Faire confiance à cet ordinateur';
 $labels['computer_private_title'] = 'Le nom d\'utilisateur ainsi que les codes de double authentification ne vous seront plus demandés lors de vos prochaines connexions depuis cet ordinateur, \nNe cochez pas cette case s\'il s\'agit d\'un ordinateur public.';
 $labels['change_user'] = 'Changer d\'utilisateur';
 


### PR DESCRIPTION
Changer le libellé de la case à cocher pour adopter une rédaction similaire à Gmail :
"Enregistrer mes informations d'identification sur cet ordinateur"
devient
« faire confiance à cet ordinateur »