### PR TITLE
0008911 - 🐛 Association d'un salon tchap existant lors de la création de l'edt

### DIFF
--- a/plugins/mel_metapage/js/functions.js
+++ b/plugins/mel_metapage/js/functions.js
@@ -874,8 +874,8 @@ function m_mp_step3_param(type) {
             <div style=margin-top:15px>
                 <h4 class="span-mel t2 first">Pour trouver l'identifiant interne d'un canal cliquer sur le nom du canal -> Paramètres -> Avancé</h34>
             </div>
-            <img src="${image_src.parametres}" width=100% alt="Pour trouver l'identifiant interne d'un canal cliquer sur le nom du canal -> Paramètres -> Avancé"/>
-            <img src="${image_src.channel_uid}" width=100% alt="Pour trouver l'identifiant interne d'un canal cliquer sur le nom du canal -> Paramètres -> Avancé"/>
+            <img src="${image_src.parametres}" width=80% style="margin-left:15%;" alt="Pour trouver l'identifiant interne d'un canal cliquer sur le nom du canal -> Paramètres -> Avancé"/>
+            <img src="${image_src.channel_uid}" width=80% style="margin-left:15%;" alt="Pour trouver l'identifiant interne d'un canal cliquer sur le nom du canal -> Paramètres -> Avancé"/>
             `,
         )
           .on('change', () => {


### PR DESCRIPTION
Lorsqu'on souhaite créer un edt et qu'on choisi d'y associer dès le début un salon déjà existant , la modale qui s'ouvre nous permet d'y saisir le lien de salon ok. Par contre l'image en arrière plan fait que le bouton retour (en bas à gauche) donne l'impression qu'il appartient à l'image, vu qu'au scroll la position est fixe par rapport à l'image et non à la modale. Faire en sorte que le bouton retour soit fixe par rapport à la modale et de diminuer la taille de l'image

pas vraiment possible de rendre le bouton retour sticky, devra attendra une refonte du système
