### PR TITLE
recette - 0009324 - 🩹 Modification chargement de la config pour les actions de CRUD

### DIFF
--- a/plugins/mel_suspects_urls/mel_suspects_urls.php
+++ b/plugins/mel_suspects_urls/mel_suspects_urls.php
@@ -58,9 +58,13 @@ class mel_suspects_urls extends bnum_plugin
    */
   function setup_task()
   {
-    if ($this->get_current_task() === 'settings') $this->load_config();
+      // Charge la config pour les settings et les actions de CRUD
+      $task = $this->get_current_task();
+      if (in_array($task, ['settings', 'suspect_urls'], true)) {
+          $this->load_config();
+      }
 
-    return $this;
+      return $this;
   }
 
   /**


### PR DESCRIPTION
Suite oubli, la config n'était chargée que pour les settings (qui gère l'affichage ou non du plugin pour les utilisateurs en fonction de leurs droits).
La correction permet donc le chargement de la config pour toutes les actions de CRUD également.

A pousser en recette pour nouveaux Tests, merci.

(Désolé je me suis trompé dans le nom de la branche lors de sa création j'ai mis 25.5 au lieu de 25.11)