### PR TITLE
recette - 0008973 - 🐛 Import ICS - Déclencher un Refresh après import

### DIFF
--- a/plugins/calendar/calendar_ui.js
+++ b/plugins/calendar/calendar_ui.js
@@ -4480,6 +4480,7 @@ function rcube_calendar_ui(settings) {
     rcmail.set_busy(false, null, me.saving_lock);
     rcmail.gui_objects.importform.reset();
 
+    // PAMELA Déclencher un Refresh après import
     p.refetch = true;
     if (p.refetch) this.refresh(p);
     // PAMELA Déclencher un Refresh après import

--- a/plugins/calendar/calendar_ui.js
+++ b/plugins/calendar/calendar_ui.js
@@ -4480,6 +4480,7 @@ function rcube_calendar_ui(settings) {
     rcmail.set_busy(false, null, me.saving_lock);
     rcmail.gui_objects.importform.reset();
 
+    p.refetch = true;
     if (p.refetch) this.refresh(p);
     // PAMELA Déclencher un Refresh après import
     rcmail.refresh();


### PR DESCRIPTION
Afin de gagner en simplicité (moins 1 clic), déclencher un refresh quand l'import est réalisé avec succès.

A l'heure actuelle et dans le contexte de mutation de l'ASP vers Mél, chaque import ICS nécessite un clic pour rafraîchir l'agenda... Un peu pénible quand même