### PR TITLE
0009377 - 🐛 Gestionnaire d'absence plane si absence de date

### DIFF
--- a/plugins/mel_moncompte/localization/fr_FR.inc
+++ b/plugins/mel_moncompte/localization/fr_FR.inc
@@ -289,6 +289,8 @@ $labels['absence_msg_interne_required'] = "Veuillez renseigner le champ message 
 $labels['absence_msg_interne_externe_required'] = "Veuillez renseigner les champs message interne et message externe.";
 $labels['absence_msg_externe_required'] = "Veuillez renseigner le champ message externe.";
 $labels['absence_msg_hebdomadaire_required'] = "Veuillez renseigner un message pour chaque absence hebdomadaire.";
+$labels['absence_dates_required'] = "Veuillez renseigner une date de début et une date de fin.";
+$labels['absence_disabled'] = "La réponse automatique d'absence a bien été désactivée.";
 
 // Gestion des listes
 $labels['gestionnairelistes'] = "Gestionnaire de listes";

--- a/plugins/mel_moncompte/moncompte/Gestionnaireabsence.php
+++ b/plugins/mel_moncompte/moncompte/Gestionnaireabsence.php
@@ -55,6 +55,16 @@ class Gestionnaireabsence extends Moncompteobject
     if ($user->authentification(Moncompte::get_current_user_password(), true)) {
       // Chargement des informations supplémenaires nécessaires
       $user->load(['outofoffices']);
+       // Persistance des messages si dates manquantes
+      if (!empty($_SESSION['absence_messages_draft'])) {
+
+        $draft = $_SESSION['absence_messages_draft'];
+
+        rcmail::get_instance()->output->set_env('moncompte_absence_texte_interne', $draft['message_interne'] ?? '');
+        rcmail::get_instance()->output->set_env('moncompte_absence_texte_externe', $draft['message_externe'] ?? '');
+
+        unset($_SESSION['absence_messages_draft']);
+      }
       // Message interne
       $internal_oof = $user->outofoffices[Outofoffice::TYPE_INTERNAL];
       // Message externe
@@ -407,6 +417,21 @@ class Gestionnaireabsence extends Moncompteobject
 
     if ($interne_enabled || $externe_enabled) {
 
+    // Dates obligatoires pour absence ponctuelle
+    if (($interne_enabled || $externe_enabled)
+        && (empty($date_debut) || empty($date_fin))) {
+
+      // On conserve les messages saisis
+      $_SESSION['absence_messages_draft'] = [
+        'message_interne' => $message_interne,
+        'message_externe' => $message_externe,
+      ];
+
+      rcmail::get_instance()->output->show_message('mel_moncompte.absence_dates_required','error');
+
+      return false; // on refuse l'enregistrement
+    }
+
       // Message Interne activé = contenu message interne obligatoire
       if ($interne_enabled && empty($message_interne)) {
         rcmail::get_instance()->output->show_message('mel_moncompte.absence_msg_interne_required', 'error');
@@ -613,7 +638,11 @@ class Gestionnaireabsence extends Moncompteobject
       $ret = $user->save();
       if (!is_null($ret)) {
         // Ok
-        rcmail::get_instance()->output->show_message('mel_moncompte.absence_ok', 'confirmation');
+        if (!$interne_enabled && !$externe_enabled) {
+          rcmail::get_instance()->output->show_message('mel_moncompte.absence_disabled','confirmation');
+        } else {
+          rcmail::get_instance()->output->show_message('mel_moncompte.absence_ok','confirmation');
+        }
 
         $event_uid = self::_get_ponct_event_uid();
         if ($status_interne == '1' || $status_externe == '1')


### PR DESCRIPTION
Lorsqu'un utilisateur oubli de renseigné les date de début et/ou fin d'une absence, il visualise désormais un message d'erreur et les textes d'absence saisis sont conservés

<img width="1013" height="758" alt="image" src="https://github.com/user-attachments/assets/81e69f5f-0c92-468a-9232-dddffb41f21a" />
