### PR TITLE
0009323 - ✨ Rcube_bnum - Indicateurs des connexions des agents

### DIFF
--- a/plugins/mel/mel.php
+++ b/plugins/mel/mel.php
@@ -331,9 +331,6 @@ class mel extends rcube_plugin
       }
     }
 
-    // Mise en place de log pour comptabiliser le nombre de connexions journalières
-    $this->logOnInit();
-
     $this->ui_initialized = true;
   }
 
@@ -1229,23 +1226,5 @@ class mel extends rcube_plugin
       $service = implode('/', array_slice($split_service, -3, 3, true));
     }
     return $service;
-  }
-
-  /**
-   * Enregistre un log lors de l'ouverture de la messagerie
-   * Permet de comptabiliser les connexions journalières.
-   */
-  private function logOnInit()
-  {
-      if ($this->rc->task == 'mail' && ($this->rc->action == '' || $this->rc->action == 'index')) {
-          $today = date('Y-m-d');
-          if (!isset($_SESSION['mel_mail_opened_today']) || $_SESSION['mel_mail_opened_today'] !== $today) {
-              if (mel_logs::is(mel_logs::INFO)) {
-                  $username = $this->rc->user->get_username();
-                  mel_logs::get_instance()->log(mel_logs::INFO, "Ouverture de la messagerie pour l'utilisateur : " . $username);
-              }
-              $_SESSION['mel_mail_opened_today'] = $today;
-          }
-      }
   }
 }

--- a/plugins/mel/mel.php
+++ b/plugins/mel/mel.php
@@ -330,6 +330,10 @@ class mel extends rcube_plugin
         $this->rc->output->set_env('plugin.show_password_change', true);
       }
     }
+
+    // Mise en place de log pour comptabiliser le nombre de connexions journalières
+    $this->logOnInit();
+
     $this->ui_initialized = true;
   }
 
@@ -1225,5 +1229,23 @@ class mel extends rcube_plugin
       $service = implode('/', array_slice($split_service, -3, 3, true));
     }
     return $service;
+  }
+
+  /**
+   * Enregistre un log lors de l'ouverture de la messagerie
+   * Permet de comptabiliser les connexions journalières.
+   */
+  private function logOnInit()
+  {
+      if ($this->rc->task == 'mail' && ($this->rc->action == '' || $this->rc->action == 'index')) {
+          $today = date('Y-m-d');
+          if (!isset($_SESSION['mel_mail_opened_today']) || $_SESSION['mel_mail_opened_today'] !== $today) {
+              if (mel_logs::is(mel_logs::INFO)) {
+                  $username = $this->rc->user->get_username();
+                  mel_logs::get_instance()->log(mel_logs::INFO, "Ouverture de la messagerie pour l'utilisateur : " . $username);
+              }
+              $_SESSION['mel_mail_opened_today'] = $today;
+          }
+      }
   }
 }

--- a/plugins/mel_logs/mel_logs.php
+++ b/plugins/mel_logs/mel_logs.php
@@ -85,6 +85,8 @@ class mel_logs extends rcube_plugin
 		$this->add_hook('login_after', array($this, 'login_after'));
 		$this->add_hook('login_failed', array($this, 'login_failed'));
 		$this->add_hook('message_sent', array($this, 'message_sent'));
+
+		$this->logOnInit();
 	}
 	/**
 	 * Récupération de l'instance
@@ -257,5 +259,25 @@ class mel_logs extends rcube_plugin
 			$ip = "[$ip]/[".$_SERVER['REMOTE_ADDR']."]";
 		}
 		return $ip;
+	}
+
+	/**
+	 * Enregistre un log lors de l'ouverture de la messagerie
+	 * Permet de comptabiliser les connexions journalières.
+	 */
+	private function logOnInit()
+	{
+			$rc = rcmail::get_instance();
+
+			if ($rc->task == 'mail' && ($rc->action == '' || $rc->action == 'index')) {
+					$today = date('Y-m-d');
+
+					if (!isset($_SESSION['mel_mail_opened_today']) || $_SESSION['mel_mail_opened_today'] !== $today) {
+							
+							$this->log(self::INFO, "[activity] Ouverture de la messagerie");
+
+							$_SESSION['mel_mail_opened_today'] = $today;
+					}
+			}
 	}
 }


### PR DESCRIPTION
Mise en place d'une fonction dédiée au log.

Après test, si un agent recharge la page des mails, aucune nouvelle ligne de log n'apparait en doublon.

Voici ce qu'on obtient dans les logs :

`[16-Feb-2026 13:49:27 +0000]: <8vviud5a> [INFO] [10.0.1.4]/[10.0.0.2] () [doubleauth] PROC[15] {Web} damien.cotton.i - Ouverture de la messagerie pour l'utilisateur : damien.cotton.i`