### PR TITLE
0008712 - 🐛 Nom de la PJ >>Décaler sur la modale event le type de fichier et la flèche de téléchargement de la pj

### DIFF
--- a/plugins/mel_metapage/js/init/events.js
+++ b/plugins/mel_metapage/js/init/events.js
@@ -1908,7 +1908,7 @@ if (rcmail && window.mel_metapage) {
                 .join('.');
 
               $(e).prepend(
-                `<div class=row><div class=col-8>${name}</div><div class=col-2>${ext}</div><div class="col-2 r-gm-col-temp" ></div></div>`,
+                `<div class=row><div class="col-8 text-truncate" title="${name}">${name}</div><div class=col-2>${ext}</div><div class="col-2 r-gm-col-temp" ></div></div>`,
               );
               $(e)
                 .find('a')


### PR DESCRIPTION
Désolé, petite erreur dans le numéro de ticket pour le nom de la branche et le commit 🤨

Si le nom de la pièce jointe est trop long il est tronqué pour ne pas empiété sur le type de la pièce jointe et l'icone de téléchargement.
Ajout d'un title pour affichage complet du nom de la pièce jointe au survol de la souris.

<img width="945" height="903" alt="image" src="https://github.com/user-attachments/assets/b0b1d696-8706-4299-a7f2-62962788b3b4" />
