### PR TITLE
0009169 - 🐛 Impossible de joindre une PJ depuis le DRIVE

### DIFF
--- a/plugins/roundrive/lib/roundrive_files_engine.php
+++ b/plugins/roundrive/lib/roundrive_files_engine.php
@@ -934,6 +934,7 @@ class roundrive_files_engine
         $COMPOSE    = null;
         $errors     = array();
 
+        //MAJ de la méthode du compose ID - 0009169
         if ($COMPOSE_ID) $COMPOSE = rcmail_action_mail_compose::get_compose_data($COMPOSE_ID);
         
         if (!$COMPOSE) {

--- a/plugins/roundrive/lib/roundrive_files_engine.php
+++ b/plugins/roundrive/lib/roundrive_files_engine.php
@@ -934,10 +934,8 @@ class roundrive_files_engine
         $COMPOSE    = null;
         $errors     = array();
 
-        if ($COMPOSE_ID && $_SESSION['compose_data_'.$COMPOSE_ID]) {
-            $COMPOSE =& $_SESSION['compose_data_'.$COMPOSE_ID];
-        }
-
+        if ($COMPOSE_ID) $COMPOSE = rcmail_action_mail_compose::get_compose_data($COMPOSE_ID);
+        
         if (!$COMPOSE) {
             die("Invalid session var!");
         }
@@ -1044,6 +1042,8 @@ class roundrive_files_engine
                 $errors[] = $this->plugin->gettext('attacherror');
             }
         }
+
+        rcmail_action_mail_compose::set_compose_data($COMPOSE_ID, $COMPOSE);
 
         if (!empty($errors)) {
             $this->rc->output->command('display_message', $this->plugin->gettext('attacherror'), 'error');


### PR DESCRIPTION
"Lors de l’ajout dans un mail en rédaction d’une pièce jointe depuis le cloud nextcloud intégré au Bnum, l’intégration échoue. La pièce jointe est intégrée en tant que pièce jointe et non lien."

La gestion du compose_id ne se basait pas sur la nouvelle méthode de gestion du compose_id.