### PR TITLE
#426 - 🐛 Loguer sur la task bnum afin de comptabiliser toutes les connexions agents

### DIFF
--- a/plugins/mel_logs/mel_logs.php
+++ b/plugins/mel_logs/mel_logs.php
@@ -262,21 +262,19 @@ class mel_logs extends rcube_plugin
 	}
 
 	/**
-	 * Enregistre un log lors de l'ouverture de la messagerie
+	 * Enregistre un log lors de l'ouverture du bnum
 	 * Permet de comptabiliser les connexions journalières.
 	 */
 	private function logOnInit()
 	{
 			$rc = rcmail::get_instance();
 
-			if ($rc->task == 'mail' && ($rc->action == '' || $rc->action == 'index')) {
+			if ($rc->task === 'bnum' && $rc->action === '') {
 					$today = date('Y-m-d');
 
-					if (!isset($_SESSION['mel_mail_opened_today']) || $_SESSION['mel_mail_opened_today'] !== $today) {
-							
-							$this->log(self::INFO, "[activity] Ouverture de la messagerie");
-
-							$_SESSION['mel_mail_opened_today'] = $today;
+					if (!isset($_SESSION['bnum_opened_today']) || $_SESSION['bnum_opened_today'] !== $today) {
+							$this->log(self::INFO, "[activity] Ouverture du bnum");
+							$_SESSION['bnum_opened_today'] = $today;
 					}
 			}
 	}


### PR DESCRIPTION
Dans les logs après test j'obtiens :

`[25-Feb-2026 11:38:37 +0000]: <9lb76u0m> [INFO] [10.0.1.5]/[10.0.0.2] () [doubleauth] PROC[14] {Web} damien.cotton.i - [activity] Ouverture du bnum`

Attention par contre si l’utilisateur change de navigateur, supprime ses cookies, ou se reconnecte différemment, une nouvelle ligne de log sera comptabilisée.