### PR TITLE
0009308 - ✨ Limiter l'accès a l'annuaire ministériel et interministériel sur internet sans 2FA

### DIFF
--- a/plugins/annuaire/annuaire.php
+++ b/plugins/annuaire/annuaire.php
@@ -719,7 +719,7 @@ class annuaire extends bnum_plugin
      */
     public function config_get($args) {
         //limiter l'affichage de l'annuaire ministériel au service dans lequel on se situe
-        if ($args['name'] == 'annuaire_base_dn' && !mel::is_internal()) {
+        if ($args['name'] == 'annuaire_base_dn' && !mel::is_secured()) {
             $args['result'] = explode(',', driver_mel::gi()->getUser()->dn, 2)[1];
         }
         return $args;

--- a/plugins/annuaire/annuaire.php
+++ b/plugins/annuaire/annuaire.php
@@ -82,6 +82,8 @@ class annuaire extends bnum_plugin
         // hook for saving search
         $this->add_hook('saved_search_create', [$this, 'saved_search_create']);
         $this->add_hook('saved_search_delete', [$this, 'saved_search_delete']);
+        //hook for limited access
+        $this->add_hook('config_get', array($this, 'config_get'));
 
         if ($this->rc->task == 'addressbook') {
             // Chargement de la conf
@@ -708,6 +710,17 @@ class annuaire extends bnum_plugin
                 $this->rc->output->show_message('savedsearchdeleteerror', 'error');
 
             $this->rc->output->send();
+        }
+        return $args;
+    }
+
+    /**
+     * Modifie les éléments de config pour les utilisateurs externes
+     */
+    public function config_get($args) {
+        //limiter l'affichage de l'annuaire ministériel au service dans lequel on se situe
+        if ($args['name'] == 'annuaire_base_dn' && !mel::is_internal()) {
+            $args['result'] = explode(',', driver_mel::gi()->getUser()->dn, 2)[1];
         }
         return $args;
     }

--- a/plugins/mel/mel.php
+++ b/plugins/mel/mel.php
@@ -1227,4 +1227,14 @@ class mel extends rcube_plugin
     }
     return $service;
   }
+
+  /**
+   * Définit si on est dans une situation où l'auth est sécurisée
+   * 
+   * @return boolean
+   */
+  public function is_secured()
+  {
+    return mel::is_internal() || mel::is_auth_strong() || !class_exists('mel_doubleauth') || mel_doubleauth::is_double_auth_enable();
+  }
 }

--- a/plugins/mel/mel.php
+++ b/plugins/mel/mel.php
@@ -1233,7 +1233,7 @@ class mel extends rcube_plugin
    * 
    * @return boolean
    */
-  public function is_secured()
+  public static function is_secured()
   {
     return mel::is_internal() || mel::is_auth_strong() || !class_exists('mel_doubleauth') || mel_doubleauth::is_double_auth_enable();
   }

--- a/plugins/mel_contacts/mel_contacts.php
+++ b/plugins/mel_contacts/mel_contacts.php
@@ -276,6 +276,11 @@ class mel_contacts extends bnum_plugin
    */
   public function config_get($args)
   {
+    //limiter l'affichage de l'annuaire interministériel
+    if ($args['name'] == 'ldap_public' && !mel::is_internal()) {
+      unset($args['result']['annuaire']);
+      $args['result']['amande']['base_dn'] = explode(',', driver_mel::gi()->getUser()->dn, 2)[1];
+    }
     if ($args['name'] != 'autocomplete_addressbooks') {
       return $args;
     }

--- a/plugins/mel_contacts/mel_contacts.php
+++ b/plugins/mel_contacts/mel_contacts.php
@@ -277,7 +277,7 @@ class mel_contacts extends bnum_plugin
   public function config_get($args)
   {
     //limiter l'affichage de l'annuaire interministériel
-    if ($args['name'] == 'ldap_public' && !mel::is_internal()) {
+    if ($args['name'] == 'ldap_public' && !mel::is_secured()) {
       unset($args['result']['annuaire']);
       $args['result']['amande']['base_dn'] = explode(',', driver_mel::gi()->getUser()->dn, 2)[1];
     }


### PR DESCRIPTION
Ajouter des limitations sur les affichages de la partie Contact pour tout ce qui est ministériel et interministériel :

- L'annuaire interministériel MAIA ne doit pas être affiché si on est en connexion internet sans double auth (cela doit se règler dans la configuration)
- Pour l'annuaire ministériel (plugin annuaire), en connexion internet sans 2FA, au lieu d'afficher tout l'annuaire en base_dn il faut utiliser le dn de l'utilisateur et prendre le service (par exemple pour moi ou=PIAP,ou=GMCD,ou=DETN,ou=UNI,ou=DNUM,ou=SG,ou=AC,ou=melanie,ou=organisation,dc=equipement,dc=gouv,dc=fr) en tant que base dn du plugin