### PR TITLE
0009237 - ✨  Forcer l'affichage des calendriers que l'on souhaite utiliser dans les invitations

### DIFF
--- a/plugins/mel_moncompte/localization/fr_FR.inc
+++ b/plugins/mel_moncompte/localization/fr_FR.inc
@@ -89,6 +89,7 @@ $labels['show_resource_confirm'] = 'Ressource affichée dans le Bnum';
 $labels['sort_resource_confirm'] = 'La ressource a bien été triée';
 $labels['invitation_confirm'] = 'Ce calendrier sera utilisé dans la gestion des invitations';
 $labels['no_invitation_confirm'] = 'Ce calendrier ne sera plus utilisé dans la gestion des invitations';
+$labels['hide_calendar_invitation_forbidden'] = 'Impossible de masquer un calendrier utilisé pour les invitations';
 
 $labels['synchro_mobile_confirm'] = 'Ressource ajoutée pour la synchronisation mobile';
 $labels['no_synchro_mobile_confirm'] = 'Ressource supprimée de la synchronisation mobile';

--- a/plugins/mel_moncompte/mel_moncompte.php
+++ b/plugins/mel_moncompte/mel_moncompte.php
@@ -734,6 +734,20 @@ class mel_moncompte extends rcube_plugin {
     $type = rcube_utils::get_input_value('_type', rcube_utils::INPUT_POST);
 
     if (isset($mbox) && isset($type)) {
+       // Impossible de masquer l'agenda utilisé pour les invitations
+      if ($type === 'calendar') {
+        $no_invitation = $this->rc->user->get_prefs()['no_invitation_calendars'] ?? [];
+
+        $is_invitation_active = !isset($no_invitation[$mbox]);
+
+        if ($is_invitation_active) {
+          $this->rc->output->show_message('mel_moncompte.hide_calendar_invitation_forbidden', 'error');
+
+          $this->rc->output->command('mel_force_checkbox_on', $mbox);
+
+          return;
+        }
+      }
       $conf_name = 'hidden_' . $type . 's';
       // MANTIS 0006340: Ajouter une prop CalDAV {DAV}hidden quand un calendrier est masqué
       if ($type == 'calendar') {
@@ -745,7 +759,8 @@ class mel_moncompte extends rcube_plugin {
         $this->_set_caldav_properties($calendars_prop);
       }
       // Récupération des préférences de l'utilisateur
-      $hidden = $this->rc->config->get($conf_name, array());
+      $prefs = $this->rc->user->get_prefs();
+      $hidden = $prefs[$conf_name] ?? [];
       $hidden[$mbox] = 1;
       if ($this->rc->user->save_prefs(array($conf_name => $hidden)))
         $this->rc->output->show_message('mel_moncompte.hide_resource_confirm', 'confirmation');
@@ -797,13 +812,29 @@ class mel_moncompte extends rcube_plugin {
       // Récupération des préférences de l'utilisateur
       $no_invitation = $this->rc->config->get($conf_name, []);
       unset($no_invitation[$mbox]);
-      if ($this->rc->user->save_prefs(array($conf_name => $no_invitation)))
+
+      $hidden_conf = 'hidden_calendars';
+      $hidden = $this->rc->config->get($hidden_conf, []);
+      unset($hidden[$mbox]);
+
+      $calendars_prop = $this->_get_caldav_properties();
+      if (isset($calendars_prop[$mbox]['{DAV:}hidden'])) {
+        unset($calendars_prop[$mbox]['{DAV:}hidden']);
+        $this->_set_caldav_properties($calendars_prop);
+      }
+
+      if ($this->rc->user->save_prefs([
+        $conf_name   => $no_invitation,
+        $hidden_conf => $hidden,
+      ])) {
+
         $this->rc->output->show_message('mel_moncompte.invitation_confirm', 'confirmation');
-      else
+
+        $this->rc->output->command('mel_resources_reload_page');
+      }
+      else {
         $this->rc->output->show_message('mel_moncompte.modify_error', 'error');
-    }
-    else {
-      $this->rc->output->show_message('mel_moncompte.modify_error', 'error');
+      }
     }
   }
 

--- a/plugins/mel_moncompte/moncompte.js
+++ b/plugins/mel_moncompte/moncompte.js
@@ -1356,6 +1356,15 @@ function refreshListMembers(dn_list) {
   }
 }
 
+//Force la checkbox du calendrier à rester cochée si utilisé dans les invitations
+rcube_webmail.prototype.mel_force_checkbox_on = function (mbox) {
+  const $checkbox = $('input[name="_show_resource_rc[]"][value="' + mbox + '"]');
+
+  if ($checkbox.length) {
+    $checkbox.prop('checked', true);
+  }
+};
+
 $(document).ready(() => {
   rcmail.set_busy(false);
   parent.rcmail.set_busy(false);


### PR DESCRIPTION
Si un utilisateur coche, dans la configuration, « Utiliser ce calendrier dans les invitations » l’agenda est automatiquement coché également. Il n’est plus possible d’avoir un agenda décoché si l’utilisateur coche l’utilisation de cet agenda dans les invitations.

Un utilisateur ne peut plus décocher un agenda s’il a coché « Utiliser ce calendrier dans les invitations ». Il obtient un message d’erreur : 

<img width="945" height="523" alt="image" src="https://github.com/user-attachments/assets/66915043-c63b-48e8-80cd-780918489f0d" />
