### PR TITLE
0009239 - :sparkles: Ne pas positionner de rappel pour les évènements en journée entière

### DIFF
--- a/plugins/bnum_agenda/bnum_agenda.php
+++ b/plugins/bnum_agenda/bnum_agenda.php
@@ -227,17 +227,25 @@ class bnum_agenda extends bnum_plugin {
       //opition de rappel par defaut sur les évènements journée entière
       
       $field_id = 'allday_reminder';
+      $select_alarm_allday = new html_select(['name'=> '_allday_reminder', 'id' => $field_id]);
+      //choix du createur 
+      $alarm_options = [
+        0 => $this->rc()->gettext('none'),
+        5    => '5 minutes',
+        15   => '15 minutes',
+        30   => '30 minutes',
+        60   => '1 heure',
+        120  => '2 heures',
+        1440 => '1 jour',
+        10080 => 'une semaine',
+      ];
+      foreach($alarm_options as $val => $label){
+        $select_alarm_allday->add($label, $val);
+      }
 
-      $args['blocks']['view']['options']['allday_reminder'] = [
-        'title'   =>  html::label($field_id, rcube::Q($this->gettext('allday_reminder'))),
-        
-        'content' => html::tag('input',[
-          'type' => 'checkbox',
-          'name' => '_allday_reminder',
-          'id' => $field_id,
-          'value' => 1,
-          'checked' => (bool)$this->rc()->config->get('allday_reminder', 0)
-        ]),
+      $args['blocks']['view']['options'][$field_id] = [
+        'title'   =>  html::label($field_id, rcube::Q($this->gettext($field_id))),
+        'content' => $select_alarm_allday->show(intval($this->rc()->config->get('allday_reminder', '0'))),
       ];
     }
     return $args;
@@ -256,7 +264,7 @@ class bnum_agenda extends bnum_plugin {
       $args['prefs']['event_limit'] = rcube_utils::get_input_value('_event_limit', rcube_utils::INPUT_POST);
       $this->rc()->output->set_env('event_limit', $args['prefs']['event_limit']);
 
-      $args['prefs']['allday_reminder'] = (bool)rcube_utils::get_input_value('_allday_reminder', rcube_utils::INPUT_POST);
+      $args['prefs']['allday_reminder'] = intval(rcube_utils::get_input_value('_allday_reminder', rcube_utils::INPUT_POST));
       $this->rc()->output->set_env('allday_reminder', $args['prefs']['allday_reminder']);
     }
     return $args;

--- a/plugins/bnum_agenda/bnum_agenda.php
+++ b/plugins/bnum_agenda/bnum_agenda.php
@@ -222,6 +222,23 @@ class bnum_agenda extends bnum_plugin {
         'title'   => html::label($field_id, rcube::Q($this->gettext('event_limit'))),
         'content' => $select->show(intval($this->rc()->config->get('event_limit', 4))),
       ];
+      // Test minimal
+      
+      //opition de rappel par defaut sur les évènements journée entière
+      
+      $field_id = 'allday_reminder';
+
+      $args['blocks']['view']['options']['allday_reminder'] = [
+        'title'   =>  html::label($field_id, rcube::Q($this->gettext('allday_reminder'))),
+        
+        'content' => html::tag('input',[
+          'type' => 'checkbox',
+          'name' => '_allday_reminder',
+          'id' => $field_id,
+          'value' => 1,
+          'checked' => (bool)$this->rc()->config->get('allday_reminder', 0)
+        ]),
+      ];
     }
     return $args;
   }
@@ -238,6 +255,9 @@ class bnum_agenda extends bnum_plugin {
     if ($args['section'] === 'calendar') {
       $args['prefs']['event_limit'] = rcube_utils::get_input_value('_event_limit', rcube_utils::INPUT_POST);
       $this->rc()->output->set_env('event_limit', $args['prefs']['event_limit']);
+
+      $args['prefs']['allday_reminder'] = (bool)rcube_utils::get_input_value('_allday_reminder', rcube_utils::INPUT_POST);
+      $this->rc()->output->set_env('allday_reminder', $args['prefs']['allday_reminder']);
     }
     return $args;
   }

--- a/plugins/bnum_agenda/localization/fr_FR.inc
+++ b/plugins/bnum_agenda/localization/fr_FR.inc
@@ -2,6 +2,7 @@
 $labels['calendlink'] = 'Lien vers la prise de rendez-vous';
 $labels['calendlink-label'] = 'Pour prendre rendez-vous : cliquez ici';
 $labels['event_limit'] = 'Nombres maximum d\'évènements affichés';
+$labels['allday_reminder'] = 'Aucun rappel pour les évènements de journée entière';
 $labels['event-is-recur'] = 'Attention, vous allez copier la série complète de la récurrence, la copie d\'une seule occurrence n\'est pas possible.\nVoulez-vous quand même continuer ?';
 $labels['event-get-error'] = 'Erreur lors de la récupération de l\'événement maître';
 $labels['event-not-recur-error'] = 'L\'évènement sélectionné n\'est pas une exception ou récurrent.';

--- a/plugins/mel_metapage/js/init/events.js
+++ b/plugins/mel_metapage/js/init/events.js
@@ -1,3 +1,5 @@
+import { eventDefsToEventInstances } from "../../../calendar/lib/js/fullcalendar";
+
 function MetapageEventKey(key) {
   return {
     key: key,
@@ -1203,7 +1205,7 @@ if (rcmail && window.mel_metapage) {
       let rec =
         event.recurrence_text === undefined ? null : event.recurrence_text;
       let alarm =
-        event.alarms !== undefined ? new Alarm(event.alarms).toString() : null;
+        event.alarms !== undefined && !(event.allDay && !rcmail.env.allday_reminder) ? new Alarm(event.alarms).toString() : null;
 
       html += `<div class=row style="margin-top:5px">${rec !== null ? `<div class=col-6>${rec}</div>` : ''}${alarm !== null ? `<div class=col-6><span class="icon-mel-notif mel-cal-icon"></span>Rappel : ${alarm}</div>` : ''}</div>`;
 

--- a/plugins/mel_metapage/js/init/events.js
+++ b/plugins/mel_metapage/js/init/events.js
@@ -1,4 +1,4 @@
-import { eventDefsToEventInstances } from "../../../calendar/lib/js/fullcalendar";
+
 
 function MetapageEventKey(key) {
   return {
@@ -1205,7 +1205,7 @@ if (rcmail && window.mel_metapage) {
       let rec =
         event.recurrence_text === undefined ? null : event.recurrence_text;
       let alarm =
-        event.alarms !== undefined && !(event.allDay && !rcmail.env.allday_reminder) ? new Alarm(event.alarms).toString() : null;
+        event.alarms !== undefined && event.allDay  ? new Alarm(event.alarms).toString() : null;
 
       html += `<div class=row style="margin-top:5px">${rec !== null ? `<div class=col-6>${rec}</div>` : ''}${alarm !== null ? `<div class=col-6><span class="icon-mel-notif mel-cal-icon"></span>Rappel : ${alarm}</div>` : ''}</div>`;
 

--- a/plugins/mel_metapage/js/lib/calendar/calendar_alarm.js
+++ b/plugins/mel_metapage/js/lib/calendar/calendar_alarm.js
@@ -2,6 +2,7 @@ import { AlarmManager } from "./alarms_manager.js";
 import { Alarm } from "./alarms.js";
 import { MelObject } from "../mel_object.js";
 import { MelEnumerable } from "../classes/enum.js";
+import { eventDefsToEventInstances } from "../../../../calendar/lib/js/fullcalendar.js";
 
 /**
  * Gère les alarmes de l'agenda
@@ -246,8 +247,9 @@ export class Calendar_Alarm extends MelObject
         const alarm_is_defined = event.alarms !== undefined && event.alarms !== null;
         const alarm_not_dismissed = event.alarm_dismissed !== true;
         const event_not_annulated = event.status !== "CANCELLED";
+        const allday_reminder_enabled = !event.allDay || this.rcmail.env.allday_reminder;
 
-        return alarm_is_defined && alarm_not_dismissed && event_not_annulated;
+        return alarm_is_defined && alarm_not_dismissed && event_not_annulated && allday_reminder_enabled;
     }
 
 }

--- a/plugins/mel_metapage/js/lib/calendar/calendar_alarm.js
+++ b/plugins/mel_metapage/js/lib/calendar/calendar_alarm.js
@@ -2,7 +2,7 @@ import { AlarmManager } from "./alarms_manager.js";
 import { Alarm } from "./alarms.js";
 import { MelObject } from "../mel_object.js";
 import { MelEnumerable } from "../classes/enum.js";
-import { eventDefsToEventInstances } from "../../../../calendar/lib/js/fullcalendar.js";
+//import { eventDefsToEventInstances } from "../../../../calendar/lib/js/fullcalendar.js";
 
 /**
  * Gère les alarmes de l'agenda
@@ -247,9 +247,10 @@ export class Calendar_Alarm extends MelObject
         const alarm_is_defined = event.alarms !== undefined && event.alarms !== null;
         const alarm_not_dismissed = event.alarm_dismissed !== true;
         const event_not_annulated = event.status !== "CANCELLED";
-        const allday_reminder_enabled = !event.allDay || this.rcmail.env.allday_reminder;
+        //si l'user change sa préférence déjà sauvegardée qui est different de 0=aucun et revient à aucun 
+        // const allday_reminder_enabled = !event.allDay || parseInt( this.rcmail.env.allday_reminder ?? 0) > 0;
 
-        return alarm_is_defined && alarm_not_dismissed && event_not_annulated && allday_reminder_enabled;
+        return alarm_is_defined && alarm_not_dismissed && event_not_annulated;
     }
 
 }

--- a/plugins/mel_metapage/js/lib/calendar/event/event_view.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/event_view.js
@@ -48,6 +48,7 @@ import { CalendarOwner } from './parts/calendarparts.js';
 import { CategoryPart } from './parts/categoryparts.js';
 import { GuestsPart } from './parts/guestspart.js';
 import { LocationPartManager } from './parts/location_part.js';
+import { Parts } from './parts/parts.js';
 import { RecPart } from './parts/recpart.js';
 import { SensitivityPart } from './parts/sensitivitypart.js';
 import { StatePart } from './parts/statepart.js';
@@ -450,6 +451,8 @@ export class EventView {
   _setup(event, dialog) {
     this._event = event;
     this._dialog = dialog;
+    //detecter si on est en creation ou en édition (evenement en creation n'a pas de l'id)
+    Parts.isStartEvent = false;
 
     this.inputs = new EventManager(...EventView.true_selectors).generate();
     this.fakes = new EventManager(...EventView.false_selectors).generate();

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/parts.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/parts.js
@@ -188,7 +188,15 @@ class FakePart extends Parts {
  * @enum {Symbol}
  */
 Parts.MODE = {
-  change: Symbol(),
-  click: Symbol(),
-  input: Symbol(),
+    change:Symbol(),
+    click:Symbol(),
+    input:Symbol()
 };
+
+/**
+ * Indique si on est en mode création d'évènement ou en mode édition.
+ * true = création, false = édition
+ * @static
+ * @type {boolean}
+ */
+Parts.isStartEvent = false;

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/timepart.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/timepart.js
@@ -458,46 +458,42 @@ export class TimePartManager {
    */
   _on_all_day_changed(e) {
     const isAllDay = $(e.currentTarget)[0].checked;
-    const alldayReminderEnabled = rcmail.env.allday_reminder;
     const $reminder = $('#mel-calendar-alarm');
 
+    const toggleClass = (part, add) => part._$fakeField
+        .css('display', add ? 'none' : EMPTY_STRING)
+        .parent()
+        .parent()
+        [add ? 'addClass' : 'removeClass'](CLASS_ALL_DAY);
 
-    if (isAllDay ) {
-      this.start._$fakeField
-        .css('display', 'none')
-        .parent()
-        .parent()
-        .addClass(CLASS_ALL_DAY);
-      this.end._$fakeField
-        .css('display', 'none')
-        .parent()
-        .parent()
-        .addClass(CLASS_ALL_DAY);
-       // mettre la valeur à "aucune" dès que l'évènement est en journée entière 
-      if (!alldayReminderEnabled){
-         $reminder.val('0').trigger('change');
-       }
+    toggleClass(this.start, isAllDay);
+    toggleClass(this.end, isAllDay);
 
+    // On ne touche au rappel qu'en mode création
+    // if (Parts.isStartEvent) return;
+
+    if (isAllDay) {
+      // debugger;
+        // Journée entière en création : appliquer le rappel par défaut allday
+        const alldayReminder = rcmail.env.allday_reminder;
+
+        if (alldayReminder !== undefined && alldayReminder !== 0) {
+            $reminder.val(alldayReminder).trigger('change');
+        } else {
+            $reminder.val('0').trigger('change');
+        }
     } else {
-      this.start._$fakeField
-        .css('display', EMPTY_STRING)
-        .parent()
-        .parent()
-        .removeClass(CLASS_ALL_DAY);
-      this.end._$fakeField
-        .css('display', EMPTY_STRING)
-        .parent()
-        .parent()
-        .removeClass(CLASS_ALL_DAY);
-
-        //remetre le paramettre à defaut si l'évènement n'est pas en journée entrière 
-      const defaultAlarm = rcmail.env.calendar_settings?.alarm_minutes ?? '15';
-      $reminder.val(defaultAlarm).trigger('change');
-      
-    }
+        // Pas journée entière en création : remettre le rappel par défaut du calendrier
+        const calendarDefaultAlarm = rcmail.env.calendar_settings?.alarm_minutes ?? '15';
+        $reminder.val(String(calendarDefaultAlarm)).trigger('change');
+       
+        }
   }
-
-  /**
+    
+    /**
+     const defaultAlarm = rcmail.env.calendar_settings?.alarm_minutes ?? '15';
+     $reminder.val(defaultAlarm).trigger('change');
+     
    * Met à jour le select en ajoutant une option qui n'éxiste pas.
    * @param {string} select Id du select
    * @param {string} value Valeur à ajouter. Le format doit être 'HH:mm'

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/timepart.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/timepart.js
@@ -457,7 +457,12 @@ export class TimePartManager {
    * @param {Event} e
    */
   _on_all_day_changed(e) {
-    if ($(e.currentTarget)[0].checked) {
+    const isAllDay = $(e.currentTarget)[0].checked;
+    const alldayReminderEnabled = rcmail.env.allday_reminder;
+    const $reminder = $('#mel-calendar-alarm');
+
+
+    if (isAllDay ) {
       this.start._$fakeField
         .css('display', 'none')
         .parent()
@@ -468,6 +473,11 @@ export class TimePartManager {
         .parent()
         .parent()
         .addClass(CLASS_ALL_DAY);
+       // mettre la valeur à "aucune" dès que l'évènement est en journée entière 
+      if (!alldayReminderEnabled){
+         $reminder.val('0').trigger('change');
+       }
+
     } else {
       this.start._$fakeField
         .css('display', EMPTY_STRING)
@@ -479,6 +489,11 @@ export class TimePartManager {
         .parent()
         .parent()
         .removeClass(CLASS_ALL_DAY);
+
+        //remetre le paramettre à defaut si l'évènement n'est pas en journée entrière 
+      const defaultAlarm = rcmail.env.calendar_settings?.alarm_minutes ?? '15';
+      $reminder.val(defaultAlarm).trigger('change');
+      
     }
   }
 

--- a/plugins/mel_metapage/mel_metapage.php
+++ b/plugins/mel_metapage/mel_metapage.php
@@ -566,6 +566,7 @@ class mel_metapage extends bnum_plugin
 
             if ($this->rc->task === "calendar") {
                 $this->rc->output->set_env("calendar_custom_dialog", true);
+                $this->rc->output->set_env("allday_reminder", $this->rc()->config->get('allday_reminder', false));
 
                 if ($this->rc->action === '' || $this->rc->action === 'index') {
                     $this->load_script_module('main', '/js/lib/calendar/');

--- a/plugins/mel_metapage/mel_metapage.php
+++ b/plugins/mel_metapage/mel_metapage.php
@@ -566,7 +566,7 @@ class mel_metapage extends bnum_plugin
 
             if ($this->rc->task === "calendar") {
                 $this->rc->output->set_env("calendar_custom_dialog", true);
-                $this->rc->output->set_env("allday_reminder", $this->rc()->config->get('allday_reminder', false));
+                $this->rc->output->set_env("allday_reminder", intval($this->rc()->config->get('allday_reminder', 0)));
 
                 if ($this->rc->action === '' || $this->rc->action === 'index') {
                     $this->load_script_module('main', '/js/lib/calendar/');


### PR DESCRIPTION
Cette modification permet de ne recevoir aucun rappel pour les évènements en journée entière(cela se fait de manière dinamique dès que la journée entière est activée)