### PR TITLE
0008779: - 🌐 Traduction non faite pour un affichage agenda en partage avec droit "Affichage"

### DIFF
--- a/plugins/calendar/localization/fr_FR.inc
+++ b/plugins/calendar/localization/fr_FR.inc
@@ -335,6 +335,8 @@ $labels['gereragenda'] = 'Gérer les agendas';
 // MANTIS 3607: Permettre de remplacer tous les évènements lors d'un import
 $labels['deleteallcalendarconfirm'] = 'Voulez-vous vraiment supprimer tous les évènements de cet agenda (l\'opération ne peut pas être annulée) ?';
 $labels['event private'] = "Évènement privé";
+$labels['event busy'] = "Évènement occupé";
+$labels['event tentative'] = "Évènement provisoire";
 $labels['copied_url'] = 'Lien copié !';
 $labels['copied_url_default'] = 'Copier le lien';
 $labels['copied_url_title'] = 'Cliquez-ici pour copier le lien de l\'agenda';


### PR DESCRIPTION
A partage son agenda à B avec juste les droits "Affichage "Pour B, dans son agenda, le nom donné à l'évt de A s'affiche en anglais avec "[event busy]"