### PR TITLE
0009239 - :sparkles: Ne pas positionner de rappel pour les évènements en journée entière

### DIFF
--- a/plugins/mel_metapage/js/lib/calendar/event/event_view.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/event_view.js
@@ -695,7 +695,7 @@ export class EventView {
     }
     
     const $alarmField = this.parts.alarm._$fakeField;
-    if (is_valid && rcmail.env['__local:part:isStartEvent'] && +this.parts.alarm._$fakeField.val() === -2) {
+    if (is_valid && rcmail.env['__local:part:isStartEvent'] && +$alarmField.val() === -2) {
       $alarmField.val(this.parts.date.is_all_day() ? 0 : this.parts.alarm._getDefaultAlarmMinutes()).change();
     }
 

--- a/plugins/mel_metapage/js/lib/calendar/event/event_view.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/event_view.js
@@ -451,12 +451,6 @@ export class EventView {
     this._event = event;
     this._dialog = dialog;
 
-    // const hasTitle =
-    //     event.title !== EMPTY_STRING &&
-    //     event.title !== null &&
-    //     event.title !== undefined;
-    // rcmail.env['__local:part:isStartEvent'] = !hasTitle;
-
     this.inputs = new EventManager(...EventView.true_selectors).generate();
     this.fakes = new EventManager(...EventView.false_selectors).generate();
     this.parts = new EventParts(this.inputs, this.fakes, dialog);
@@ -688,13 +682,9 @@ export class EventView {
       is_valid = false;
     }
     
-    // this.#_resolveAlarmSentinel();
-    
     this.#_setModifier();
-    
     if (!this.#_recEndDateValid()) {
       const localizationKey = 'event-not-ok-rec-date';
-      
       is_valid = false;
       BnumMessage.DisplayMessage(
         ABaseMelObject.Empty().getLocalization(localizationKey, {
@@ -705,7 +695,6 @@ export class EventView {
     }
     
     if ( is_valid && rcmail.env['__local:part:isStartEvent'] ) {
-      debugger;
       if (+this.parts.alarm._$fakeField.val() === -2) {
         if (this.parts.date.is_all_day) {
           this.parts.alarm._$fakeField.val("0");
@@ -718,8 +707,6 @@ export class EventView {
 
     return is_valid;
   }
-
-  
 
   /**
    * Vérifie si la date de réccurence de fin est valide.

--- a/plugins/mel_metapage/js/lib/calendar/event/event_view.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/event_view.js
@@ -694,8 +694,8 @@ export class EventView {
       );
     }
     
+    const $alarmField = this.parts.alarm._$fakeField;
     if (is_valid && rcmail.env['__local:part:isStartEvent'] && +this.parts.alarm._$fakeField.val() === -2) {
-      const $alarmField = this.parts.alarm._$fakeField;
       $alarmField.val(this.parts.date.is_all_day() ? 0 : this.parts.alarm._getDefaultAlarmMinutes()).change();
     }
 

--- a/plugins/mel_metapage/js/lib/calendar/event/event_view.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/event_view.js
@@ -451,6 +451,12 @@ export class EventView {
     this._event = event;
     this._dialog = dialog;
 
+    // const hasTitle =
+    //     event.title !== EMPTY_STRING &&
+    //     event.title !== null &&
+    //     event.title !== undefined;
+    // rcmail.env['__local:part:isStartEvent'] = !hasTitle;
+
     this.inputs = new EventManager(...EventView.true_selectors).generate();
     this.fakes = new EventManager(...EventView.false_selectors).generate();
     this.parts = new EventParts(this.inputs, this.fakes, dialog);
@@ -673,7 +679,7 @@ export class EventView {
     let is_valid = true;
 
     await this.parts.location.waitComplete();
-
+    
     if (!this.parts.location.is_valid()) {
       this.parts.location.invalid_action();
       is_valid = false;
@@ -681,12 +687,14 @@ export class EventView {
       this.parts.date.invalid_action();
       is_valid = false;
     }
-
+    
+    // this.#_resolveAlarmSentinel();
+    
     this.#_setModifier();
-
+    
     if (!this.#_recEndDateValid()) {
       const localizationKey = 'event-not-ok-rec-date';
-
+      
       is_valid = false;
       BnumMessage.DisplayMessage(
         ABaseMelObject.Empty().getLocalization(localizationKey, {
@@ -695,9 +703,23 @@ export class EventView {
         eMessageType.Error,
       );
     }
+    
+    if ( is_valid && rcmail.env['__local:part:isStartEvent'] ) {
+      debugger;
+      if (+this.parts.alarm._$fakeField.val() === -2) {
+        if (this.parts.date.is_all_day) {
+          this.parts.alarm._$fakeField.val("0");
+        } else {
+          this.parts.alarm._$fakeField.val(this.parts.alarm._getDefaultAlarmMinutes());
+        }
+        this.parts.alarm._$fakeField.change();
+      }
+    }
 
     return is_valid;
   }
+
+  
 
   /**
    * Vérifie si la date de réccurence de fin est valide.

--- a/plugins/mel_metapage/js/lib/calendar/event/event_view.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/event_view.js
@@ -694,15 +694,9 @@ export class EventView {
       );
     }
     
-    if ( is_valid && rcmail.env['__local:part:isStartEvent'] ) {
-      if (+this.parts.alarm._$fakeField.val() === -2) {
-        if (this.parts.date.is_all_day) {
-          this.parts.alarm._$fakeField.val("0");
-        } else {
-          this.parts.alarm._$fakeField.val(this.parts.alarm._getDefaultAlarmMinutes());
-        }
-        this.parts.alarm._$fakeField.change();
-      }
+    if (is_valid && rcmail.env['__local:part:isStartEvent'] && +this.parts.alarm._$fakeField.val() === -2) {
+      const $alarmField = this.parts.alarm._$fakeField;
+      $alarmField.val(this.parts.date.is_all_day() ? 0 : this.parts.alarm._getDefaultAlarmMinutes()).change();
     }
 
     return is_valid;

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/alarmpart.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/alarmpart.js
@@ -298,9 +298,7 @@ export class AlarmPart extends FakePart {
 
 		//Génère les options du select
 		let $option;
-		// let default_text = event.allDay ? " (aucun)" : " (15 min)";
 		for (const alarm of options_alarms) {
-			// debugger;
 			if (alarm.value === -2  ) {
 				if(rcmail.env['__local:part:isStartEvent'] === true){
 
@@ -328,7 +326,6 @@ export class AlarmPart extends FakePart {
 			}
 
 		}
-
 		$option = null;
 
 		// En mode création : écoute le basculement allDay pour mettre à jour
@@ -513,7 +510,6 @@ export class AlarmPart extends FakePart {
  * @property {string} label Sera affiché
  * @property {number} value Valeur en minute
  */
-// AlarmPart.DEFAULT_ALARM_VALUE = -2;
 /**
  * Liste des rappels prédéfinis
  * @type {Array<PredefinedOption>}

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/alarmpart.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/alarmpart.js
@@ -159,7 +159,7 @@ class AlarmData {
 				break;
 
 			default:
-				text_key = 'minutes';
+				text_key = 'minute';
 				break;
 		}
 
@@ -298,22 +298,67 @@ export class AlarmPart extends FakePart {
 
 		//Génère les options du select
 		let $option;
+		// let default_text = event.allDay ? " (aucun)" : " (15 min)";
 		for (const alarm of options_alarms) {
-			$option = MelHtml.start
-				.option({ value: alarm.value })
-				.text(alarm.label)
-				.end()
-				.generate()
-				.appendTo(this._$fakeField);
+			// debugger;
+			if (alarm.value === -2  ) {
+				if(rcmail.env['__local:part:isStartEvent'] === true){
 
-			if (alarm.value === val) {
-				$option.attr('selected', 'selected');
+					// let default_text = event.allDay ? " (aucun)" : " (15 min)";
+					$option = MelHtml.start
+						.option({ value: alarm.value })
+						.text(alarm.label + this._getDefaultText())
+						.end()
+						.generate()
+						.appendTo(this._$fakeField);
+					$option.attr('selected', 'selected').data('label', alarm.label);
+				}
+				
 			}
+			else{
+				$option = MelHtml.start
+					.option({ value: alarm.value })
+					.text(alarm.label )
+					.end()
+					.generate()
+					.appendTo(this._$fakeField);
+				if (alarm.value === val) {
+					$option.attr('selected', 'selected');
+				}
+			}
+
 		}
 
 		$option = null;
 
+		// En mode création : écoute le basculement allDay pour mettre à jour
+		// le texte de l'option "Par défaut" entre "(aucun)" et "(15 min)".
+
+		if (this.isStartEvent) {
+			$('#edit-allday').off('change.alarmpart-label').on('change.alarmpart-label', () => {
+				const $opt = this._$fakeField.find(`option[value= -2]`);
+				$opt.text($opt.data('label') + this._getDefaultText());
+			});
+		}
+
 		return this;
+	}
+
+	/**
+	 * Retourne le texte à afficher entre parenthèses pour l'option « Par défaut ».
+	 *
+	 * Retourne ``" (aucun)"`` si ``allDay`` est ``true`` ou si aucun rappel par défaut
+	 * n'est configuré, sinon retourne la durée lisible, ex. ``" (10 minutes)"``.
+	 * 
+	 * @returns {string}
+	 */
+	_getDefaultText() {
+		const isAllDay = $('#edit-allday').is(':checked');
+		if (isAllDay) return ' (aucun)';
+		const minutes = this._getDefaultAlarmMinutes();
+		if (minutes === null) return ' (aucun)';
+		debugger;
+		return ` (${new AlarmData(minutes).toString()})`;
 	}
 
 	/**
@@ -433,6 +478,33 @@ export class AlarmPart extends FakePart {
 			this._$fakeField.val(0);
 		});
 	}
+
+	/**
+	 * Récupère la valeur du rappel par défaut en minutes depuis l'environnement
+	 * rcmail, ou ``null`` si aucun rappel par défaut n'est configuré.
+	 *
+	 * @private
+	 * @returns {number|null}
+	 */
+	_getDefaultAlarmMinutes() {
+		// debugger;
+		const raw = rcmail.env.calendar_default_alarm_offset;
+		if (!raw) return null;
+ 
+		const match = raw.match(/(\d+)([MHDW])/i);
+		if (!match) return null;
+ 
+		const num = parseInt(match[1], 10);
+		const unit = match[2];//.toUpperCase();
+ 
+		switch (unit) {
+			case 'W': return num * 60 * 24 * 7;
+			case 'D': return num * 60 * 24;
+			case 'H': return num * 60;
+			default:  return num; // 'M'
+		}
+	} 
+
 }
 
 /**
@@ -441,7 +513,7 @@ export class AlarmPart extends FakePart {
  * @property {string} label Sera affiché
  * @property {number} value Valeur en minute
  */
-
+// AlarmPart.DEFAULT_ALARM_VALUE = -2;
 /**
  * Liste des rappels prédéfinis
  * @type {Array<PredefinedOption>}
@@ -458,4 +530,5 @@ AlarmPart.PREDEFINED = [
 	{ label: '1 jour', value: 60 * 24 },
 	{ label: '1 semaine', value: 60 * 24 * 7 },
 	{ label: 'Personnalisé', value: -1 },
+	{ label: 'Par défaut', value: -2 },
 ];

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/alarmpart.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/alarmpart.js
@@ -349,9 +349,8 @@ export class AlarmPart extends FakePart {
 	 */
 	_getDefaultText() {
 		const isAllDay = $('#edit-allday').is(':checked');
-		if (isAllDay) return ' (aucun)';
 		const minutes = this._getDefaultAlarmMinutes();
-		if (minutes === null) return ' (aucun)';
+		if (isAllDay || minutes === null) return ` (${AlarmPart.PREDEFINED.find(x => x.value === 0).label})`;
 		return ` (${new AlarmData(minutes).toString()})`;
 	}
 
@@ -481,7 +480,6 @@ export class AlarmPart extends FakePart {
 	 * @returns {number|null}
 	 */
 	_getDefaultAlarmMinutes() {
-		// debugger;
 		const raw = rcmail.env.calendar_default_alarm_offset;
 		if (!raw) return null;
  
@@ -512,7 +510,7 @@ export class AlarmPart extends FakePart {
  * @type {Array<PredefinedOption>}
  */
 AlarmPart.PREDEFINED = [
-	{ label: 'Aucune', value: 0 },
+	{ label: 'Aucun', value: 0 },
 	{ label: '5 minutes', value: 5 },
 	{ label: '10 minutes', value: 10 },
 	{ label: '15 minutes', value: 15 },

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/alarmpart.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/alarmpart.js
@@ -301,8 +301,6 @@ export class AlarmPart extends FakePart {
 		for (const alarm of options_alarms) {
 			if (alarm.value === -2  ) {
 				if(rcmail.env['__local:part:isStartEvent'] === true){
-
-					// let default_text = event.allDay ? " (aucun)" : " (15 min)";
 					$option = MelHtml.start
 						.option({ value: alarm.value })
 						.text(alarm.label + this._getDefaultText())
@@ -354,7 +352,6 @@ export class AlarmPart extends FakePart {
 		if (isAllDay) return ' (aucun)';
 		const minutes = this._getDefaultAlarmMinutes();
 		if (minutes === null) return ' (aucun)';
-		debugger;
 		return ` (${new AlarmData(minutes).toString()})`;
 	}
 
@@ -492,7 +489,7 @@ export class AlarmPart extends FakePart {
 		if (!match) return null;
  
 		const num = parseInt(match[1], 10);
-		const unit = match[2];//.toUpperCase();
+		const unit = match[2].toUpperCase();
  
 		switch (unit) {
 			case 'W': return num * 60 * 24 * 7;

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/parts.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/parts.js
@@ -27,7 +27,6 @@ class Parts {
      * @type {external:jQuery}
      */
     this._$field = $field;
-    // this.isStartEvent = rcmail.env['__local:part:isStartEvent'] ?? true;
     this._p_initField(modes);
   }
 
@@ -144,8 +143,6 @@ class Parts {
   get isStartEvent() {
     return MelObject.Empty().get_env('__local:part:isStartEvent') ?? true;
   }
-
-  
 }
 
 /**

--- a/plugins/mel_metapage/js/lib/calendar/event/parts/parts.js
+++ b/plugins/mel_metapage/js/lib/calendar/event/parts/parts.js
@@ -27,6 +27,7 @@ class Parts {
      * @type {external:jQuery}
      */
     this._$field = $field;
+    // this.isStartEvent = rcmail.env['__local:part:isStartEvent'] ?? true;
     this._p_initField(modes);
   }
 
@@ -143,6 +144,8 @@ class Parts {
   get isStartEvent() {
     return MelObject.Empty().get_env('__local:part:isStartEvent') ?? true;
   }
+
+  
 }
 
 /**


### PR DESCRIPTION
Ajout d'une option par défaut dans les rappels lors de la création d'un évènement.
Si allday  vaut par défaut "Aucun" sinon  vaut la valeur dans la conf aganda