### PR TITLE
0009430 - :sparkles: Créer un hook "once_per_day"

### DIFF
--- a/plugins/bnum/bnum.php
+++ b/plugins/bnum/bnum.php
@@ -22,6 +22,12 @@ class bnum extends bnum_plugin {
     if (self::IsCalendarDriverForced()) self::UnforceCalendarDriver();
 
     $this->load_config();
+    if($_SERVER['REQUEST_METHOD'] === 'GET') {
+      try {
+      $this->load_script_module('main', '/js/');
+      }catch(Error $e) {}
+    }
+    $this->add_hook('refresh', [$this, 'refresh']);
   }
 
   /**
@@ -45,5 +51,15 @@ class bnum extends bnum_plugin {
    */
   public static function IsCalendarDriverForced() : bool {
     return $_ENV[FORCE_CALENDAR_DRIVER] === true;
+  }
+
+  public function refresh($args) {
+    if(!isset($_COOKIE['once_per_day'])) {
+
+      setcookie('once_per_day', true, time()+60*60*24);
+      $this->exec_hook('once_per_day');
+
+      $this->rc()->output->command('plugin.local_once_per_day');
+    }
   }
 }

--- a/plugins/bnum/bnum.php
+++ b/plugins/bnum/bnum.php
@@ -53,6 +53,9 @@ class bnum extends bnum_plugin {
     return $_ENV[FORCE_CALENDAR_DRIVER] === true;
   }
 
+  /**
+   * Gestion du cookie once per day en php et JS
+   */
   public function refresh($args) {
     if(!isset($_COOKIE['once_per_day'])) {
 

--- a/plugins/bnum/bnum.php
+++ b/plugins/bnum/bnum.php
@@ -28,6 +28,7 @@ class bnum extends bnum_plugin {
       }catch(Error $e) {}
     }
     $this->add_hook('refresh', [$this, 'refresh']);
+    $this->add_hook('login_after', [$this, 'login_after']);
   }
 
   /**
@@ -64,5 +65,13 @@ class bnum extends bnum_plugin {
 
       $this->rc()->output->command('plugin.local_once_per_day');
     }
+  }
+
+  /**
+   * Gestion lors de la première connexion pour ne pas doubler les actions au premier refresh
+   */
+  public function login_after($args) { 
+    unset($_COOKIE['once_per_day']);
+    $this-> refresh($args);
   }
 }

--- a/plugins/bnum/js/commands.js
+++ b/plugins/bnum/js/commands.js
@@ -1,15 +1,15 @@
-import { MelObject } from "../../mel_metapage/js/lib/mel_object.js";
+import { MelObject } from '../../mel_metapage/js/lib/mel_object.js';
 
 export class Commands extends MelObject {
-    constructor() {
-        super();
+  constructor() {
+    super();
 
-        this.listen('plugin.local_once_per_day', () => {
-            this.#_oncePerDay();
-        })
-    }
+    this.listen('plugin.local_once_per_day', () => {
+      this.#_oncePerDay();
+    });
+  }
 
-    #_oncePerDay() {
-        this.trigger('once_per_day');
-    } 
+  #_oncePerDay() {
+    this.trigger('once_per_day');
+  }
 }

--- a/plugins/bnum/js/commands.js
+++ b/plugins/bnum/js/commands.js
@@ -1,5 +1,8 @@
 import { MelObject } from '../../mel_metapage/js/lib/mel_object.js';
 
+/**
+ * Class qui enregistre et lance différentes commandes/triggers
+ */
 export class Commands extends MelObject {
   constructor() {
     super();
@@ -9,6 +12,9 @@ export class Commands extends MelObject {
     });
   }
 
+  /**
+   * trigger évènement roundcube once_per_day
+   */
   #_oncePerDay() {
     this.trigger('once_per_day');
   }

--- a/plugins/bnum/js/commands.js
+++ b/plugins/bnum/js/commands.js
@@ -1,0 +1,15 @@
+import { MelObject } from "../../mel_metapage/js/lib/mel_object.js";
+
+export class Commands extends MelObject {
+    constructor() {
+        super();
+
+        this.listen('plugin.local_once_per_day', () => {
+            this.#_oncePerDay();
+        })
+    }
+
+    #_oncePerDay() {
+        this.trigger('once_per_day');
+    } 
+}

--- a/plugins/bnum/js/main.js
+++ b/plugins/bnum/js/main.js
@@ -1,0 +1,11 @@
+import { MelObject } from "../../mel_metapage/js/lib/mel_object.js";
+import { Commands } from "./commands.js";
+
+class Main extends MelObject {
+    constructor() {
+        super();
+        new Commands();
+    }
+}
+
+new Main();

--- a/plugins/bnum/js/main.js
+++ b/plugins/bnum/js/main.js
@@ -1,6 +1,9 @@
 import { MelObject } from '../../mel_metapage/js/lib/mel_object.js';
 import { Commands } from './commands.js';
 
+/**
+ * Class regroupant les différents modules du bnum
+ */
 class Main extends MelObject {
   constructor() {
     super();

--- a/plugins/bnum/js/main.js
+++ b/plugins/bnum/js/main.js
@@ -1,11 +1,11 @@
-import { MelObject } from "../../mel_metapage/js/lib/mel_object.js";
-import { Commands } from "./commands.js";
+import { MelObject } from '../../mel_metapage/js/lib/mel_object.js';
+import { Commands } from './commands.js';
 
 class Main extends MelObject {
-    constructor() {
-        super();
-        new Commands();
-    }
+  constructor() {
+    super();
+    new Commands();
+  }
 }
 
 new Main();


### PR DESCRIPTION
Créer un hook php et js qui se nomme "once_per_day"
On va laisser le plugin "bnum" gérer ça.
Ajouter le hook du refresh
Dans le hook du refresh ajouter la commande : $this->rc->output->command('local_once_per_day');
Dans le plugin bnum, ajouter 2 fichier main & commands, dans commands, ajouter la fonction once_per_day. Main enregistre la commande.
La fonction once_per_day appelle le serveur qui execute le hook once_per_day et une fois fini, elle lance trigger js once_per_day.
/!\ Attention ! Les appels sont lancer seulement si le cookie once_per_day n'existe pas. Une fois que les appels sont finis, créer ce cookie et il doit expirer le jours prochain.
Le cookie est créer après execution de once_per_day, le hook doit être appelé après la connexion aussi.
Charger main.js dans le php pour que tout puisse fonctionner.