### PR TITLE
0009432 - :sparkles: Gestion de l'expiration du mot de passe

### DIFF
--- a/plugins/mel/mel.php
+++ b/plugins/mel/mel.php
@@ -99,6 +99,7 @@ class mel extends rcube_plugin
     $this->add_hook('identity_update',      array($this, 'identity_update'));
     $this->add_hook('message_before_send',  array($this, 'message_before_send'));
     $this->add_hook('imap_search_before', [$this, 'imap_search_before']);
+    $this->add_hook('once_per_day',       [$this, 'unset_show_password_change']);
 
     // Template
     $this->add_hook('template_object_loginform',  array($this, 'login_form'));
@@ -519,6 +520,15 @@ class mel extends rcube_plugin
     foreach ($delete_identities as $delete_iid) {
       $this->rc->user->delete_identity($delete_iid);
     }
+    return $args;
+  }
+
+  /**
+   * supprime le paramètre plugin.show_password_change de la session
+   */
+  public function unset_show_password_change ($args)
+  {
+    unset($_SESSION['plugin.show_password_change']);
     return $args;
   }
 

--- a/plugins/mel/mel.php
+++ b/plugins/mel/mel.php
@@ -524,9 +524,9 @@ class mel extends rcube_plugin
   }
 
   /**
-   * supprime le paramètre plugin.show_password_change de la session
+   * Supprime le paramètre plugin.show_password_change de la session
    */
-  public function unset_show_password_change ($args)
+  public function unset_show_password_change($args)
   {
     unset($_SESSION['plugin.show_password_change']);
     return $args;


### PR DESCRIPTION
La popup de l'expiration du mdp ne se lance que à la connexion. Suite au ralongement de la durée de session, il faudrait qu'elle s'affiche une fois par jour