### PR TITLE
0009361 - ✨ Pouvoir partager un événement sans l'ICS

### DIFF
--- a/plugins/calendar/calendar.php
+++ b/plugins/calendar/calendar.php
@@ -1142,7 +1142,14 @@ $("#rcmfd_new_category").keypress(function(event) {
             break;
         //PAMELA
         case 'share':
+
+            // PAMELA - 0009361 Partage d'un évènement sans ICS
+            $this->require_plugin('mel_helper');
+
              $users_email = rcube_utils::get_input_value('_users_to_share', rcube_utils::INPUT_POST);
+
+             // PAMELA - 0009361 Partage d'un évènement sans ICS
+            $transmit_ics = (int) rcube_utils::get_input_value('_transmit_ics', rcube_utils::INPUT_POST) === 1;
 
             if (!isset($event['attendees']) || !is_array($event['attendees']))
             {
@@ -1196,6 +1203,9 @@ $("#rcmfd_new_category").keypress(function(event) {
             $event['_comment'] = rcube_utils::get_input_value('_comment', rcube_utils::INPUT_POST);
             $event['_notify'] = "3";
             $event['share'] = true;
+
+            // PAMELA - 0009361 Partage d'un évènement sans ICS
+            $event['_transmit_ics'] = $transmit_ics;
 
             $event['created'] = new Datetime($event['created']);
             $event['changed'] = new Datetime($event['changed']);
@@ -2833,6 +2843,40 @@ $("#rcmfd_new_category").keypress(function(event) {
             // skip myself for obvious reasons
             if (empty($attendee['email']) || in_array(strtolower($attendee['email']), $emails)) {
                 if (!empty($attendee['email'])) $orga = $attendee;
+                continue;
+            }
+
+            // PAMELA - 0009361 Partage d'un évènement sans ICS
+            if ($action === 'share' && isset($event['_transmit_ics']) && $event['_transmit_ics'] === false) {
+                $start = is_object($event['start']) ? $event['start']->format('d/m/Y H:i') : $event['start'];
+                $end = is_object($event['end']) ? $event['end']->format('d/m/Y H:i')   : $event['end'];
+
+                $body = $this->gettext('share_title') . ($event['title'] ?? '') . "\n\n";
+                $body .= $this->gettext('share_start') . $start . "\n";
+                $body .= $this->gettext('share_end') . $end . "\n\n";
+                $body .= $this->gettext('share_location') . ($event['location'] ?? '') . "\n\n";
+                $body .= $this->gettext('share_description') . ($event['description'] ?? '') . "\n";
+
+                if (!empty($event['_comment'])) {
+                    $body .= "\n" . $event['_comment'];
+                }
+
+                $default_identity = $this->rc->user->get_identity();
+                $from = $default_identity['email'];
+
+                $recipient = [
+                    'email' => $attendee['email'],
+                    'name' => $attendee['name'] ?? $attendee['email'],
+                ];
+
+                $sent += mel_helper::send_mail(
+                    $event['_subject'],
+                    $body,
+                    $from,
+                    $recipient,
+                    false
+                ) ? 1 : -100;
+
                 continue;
             }
 

--- a/plugins/calendar/localization/fr_FR.inc
+++ b/plugins/calendar/localization/fr_FR.inc
@@ -385,4 +385,12 @@ $labels['changerecurrence'] = 'Ancienne répétition';
 $labels['notification'] = 'Notification'; 
 // PAMELA - #386 - 🚑 Les participants invité à une réunion avec une ressource ne fonctionne pas
 $labels['rsc-denied'] = 'La ressource $name est occupée';
+
+// PAMELA - 0009361 Partage d'un évènement sans ICS
+$labels['share_title'] = 'Titre : ';
+$labels['share_start'] = 'Début : ';
+$labels['share_end'] = 'Fin : ';
+$labels['share_location'] = 'Lieu : ';
+$labels['share_description'] = 'Description : ';
+
 ?>

--- a/plugins/mel_metapage/js/init/events.js
+++ b/plugins/mel_metapage/js/init/events.js
@@ -1502,6 +1502,46 @@ if (rcmail && window.mel_metapage) {
             ),
           );
 
+          // Ajout de la checkbox
+          let $icsToggleWrapper = $(`
+            <div class="row my-2" style="margin-top:25px !important;">
+              <div class="custom-control custom-switch no-click-focus d-flex align-items-center">
+                <input name="transmit_ics" id="share-ics-toggle" type="checkbox" checked class="form-check-input custom-control-input no-click-focus">
+                <label for="share-ics-toggle" class="custom-control-label option-switch no-click-focus"></label>
+                <div class="d-flex justify-content-center align-items-center ml-2">
+                  <div>
+                    ${rcmail.gettext('mel_metapage.forword_the_invitation')}
+                    <p id="share-ics-description" style="font-size:11px; color:var(--input-mel-text-color); margin:0;">${rcmail.gettext('mel_metapage.share_ics_joined')}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          `);
+
+          // Comportement du toggle
+          $icsToggleWrapper.find('input[name="transmit_ics"]').on('change', function () {
+            const $desc = $icsToggleWrapper.find('#share-ics-description');
+
+            if (this.checked) {
+              $desc.text(rcmail.gettext('mel_metapage.share_ics_joined'));
+            } else {
+              $desc.text(rcmail.gettext('mel_metapage.share_ics_not_joined'));
+            }
+          });
+
+          $icsToggleWrapper.on('click', function (e) {
+            e.stopImmediatePropagation();
+          });
+
+          $icsToggleWrapper.find('label.custom-control-label').on('click', function (e) {
+            e.stopImmediatePropagation();
+            e.preventDefault();
+            const $cb = $icsToggleWrapper.find('input[name="transmit_ics"]');
+            $cb.prop('checked', !$cb.prop('checked')).trigger('change');
+          });
+
+          modal.appendToBody($icsToggleWrapper);
+
           modal.footer.querry.html('');
           modal.footer.querry
             .append(
@@ -1559,6 +1599,9 @@ if (rcmail && window.mel_metapage) {
                   }
                 }
 
+                //
+                const transmitIcs = $icsToggleWrapper.find('input[name="transmit_ics"]').is(':checked');
+
                 modal.close();
                 rcmail.http_post(
                   'event',
@@ -1569,6 +1612,7 @@ if (rcmail && window.mel_metapage) {
                     _comment: comment,
                     _subject: subject,
                     _organizer: event.source.ajaxSettings.owner,
+                    _transmit_ics: transmitIcs ? 1 : 0,
                   },
                   loading,
                 );

--- a/plugins/mel_metapage/localization/fr_FR.inc
+++ b/plugins/mel_metapage/localization/fr_FR.inc
@@ -534,3 +534,7 @@ $labels['image_title'] = 'Image de l\'espace de travail';
 $labels['workspace_title_min_length'] = 'Le titre de l\'espace de travail doit contenir au minimum %d caractères.';
 $labels['workspace_title_invalid_first_char'] = 'Le titre de l\'espace de travail doit commencer par une lettre ou un chiffre.';
 $labels['workspace_title_title'] = 'Le titre doit contenir au minimum %d caractères et commencer par une lettre ou un chiffre.';
+
+$labels['forword_the_invitation'] = 'Transmettre l\'invitation';
+$labels['share_ics_joined'] = 'Le fichier ICS sera joint au message';
+$labels['share_ics_not_joined'] = 'Seules les informations de l\'évènement seront envoyées (titre, horaires, lieu, description)';


### PR DESCRIPTION
Ajout d'une checkbox dans la modale de partage d'un évènement :

<img width="945" height="893" alt="image" src="https://github.com/user-attachments/assets/a87759f8-83e6-4c2c-aceb-23e940ccb4fa" />
<img width="945" height="884" alt="image" src="https://github.com/user-attachments/assets/f9fad9ca-bbf3-49bc-a8eb-95189fb123ff" />

Visuel du mail reçu sans l'ICS :

<img width="945" height="396" alt="image" src="https://github.com/user-attachments/assets/171baee1-dc94-4796-8bab-81815797438e" />
