### PR TITLE
0009144 - :bug: Création d'une tâche depuis le bouton "Créer+" la fenêtre reste au premier plan après avoir cliqué sur "Tâches"

### DIFF
--- a/plugins/mel_metapage/js/functions.js
+++ b/plugins/mel_metapage/js/functions.js
@@ -380,6 +380,11 @@ function m_mp_Create() {
  * @async
  */
 async function m_mp_Task() {
+  if (window.create_popUp !== undefined) {
+    // Fermer la boite de dialog
+    window.create_popUp.close();
+    window.create_popUp = undefined;
+  }
   await PageManager.SwitchFrame('tasks', {});
   PageManager.Instance.get_frame()[0].contentWindow.rcmail.command('newtask');
 }


### PR DESCRIPTION


Suppression de "globalmodal" pour la création d'une "Tâche"