### PR TITLE
Recette - #443 - 🐛 il était possible de valider un title de moins de 5 caractères lors de la création ou de la modification d'un edt

### DIFF
--- a/plugins/mel_metapage/js/functions.js
+++ b/plugins/mel_metapage/js/functions.js
@@ -1312,20 +1312,21 @@ async function m_mp_check_w(step, next) {
   let stop = false;
   switch (step) {
     case 1:
-      if ($('#workspace-title').val() === '') {
+      const title_error = validate_workspace_title($('#workspace-title').val());
+      if (title_error !== null) {
         $('#workspace-title').css('border-color', 'red');
-        if ($('#wspte').length === 0)
+        if ($('#wspte').length === 0) {
           $('#workspace-title')
             .parent()
-            .append(
-              '<span id=wspte class=input-error-r style=color:red></span>',
-            );
-        $('#wspte').html("* L'espace de travail doit avoir un titre !");
+            .append('<span id=wspte class=input-error-r style=color:red></span>');
+        }
+        $('#wspte').html(`* ${title_error}`);
         $('#wspte').css('display', '');
         stop = true;
       } else {
         $('#wspte').css('display', 'none');
         $('#workspace-title').css('border-color', '');
+        $('#workspace-title').val(($('#workspace-title').val() || '').trim());
       }
       if (
         $('#workspace-private')[0].checked === false &&

--- a/plugins/mel_metapage/js/functions.js
+++ b/plugins/mel_metapage/js/functions.js
@@ -1320,7 +1320,6 @@ async function m_mp_check_w(step, next) {
             .parent()
             .append('<span id=wspte class=input-error-r style=color:red></span>');
         }
-        // $('#wspte').html(`* ${title_error}`);
         $('#wspte').css('display', '');
         stop = true;
       } else {

--- a/plugins/mel_metapage/js/functions.js
+++ b/plugins/mel_metapage/js/functions.js
@@ -1320,7 +1320,7 @@ async function m_mp_check_w(step, next) {
             .parent()
             .append('<span id=wspte class=input-error-r style=color:red></span>');
         }
-        $('#wspte').html(`* ${title_error}`);
+        // $('#wspte').html(`* ${title_error}`);
         $('#wspte').css('display', '');
         stop = true;
       } else {

--- a/plugins/mel_workspace/js/params.js
+++ b/plugins/mel_workspace/js/params.js
@@ -1862,13 +1862,25 @@
     rcmail.register_command(
       'workspace.update_title',
       () => {
+        const $title = $('#spaceTitle');
+        const title = ($title.val() || '').trim();
+        const titleError = validate_workspace_title(title);
+
+        if (titleError !== null) {
+          $title.css('border-color', 'red');
+          rcmail.display_message(titleError, 'error');
+          $title.focus();
+          return;
+        }
+        $title.val(title);
+        
         if (
           !confirm(rcmail.gettext('change_title_confirmation', 'mel_workspace'))
         )
           return;
         rcmail.env.WSP_Param.update_primary_parameters({
           type: 'title',
-          input: $('#spaceTitle'),
+          input: $title,
           checks: 'empty;already-exist',
           text_on_error:
             "Une erreur est survenue.\r\nImpossible de changer le titre de l'espace.",

--- a/plugins/mel_workspace/mel_workspace.php
+++ b/plugins/mel_workspace/mel_workspace.php
@@ -412,7 +412,7 @@ class mel_workspace extends bnum_plugin
             // validation du titre de l'edt
             $validation = $this->_validate_workspace_title($data['title']);
             if ($validation !== true) {
-                $this->sendEncodeExit(['error' => $validation]);
+                $this->sendEncodedExit(['error' => $validation], []);
             }
 
             if ($data["color"] === "" || $data["color"] === null) $data["color"] = "#FFFFFF";


### PR DESCRIPTION
Après test il n'est désormais plus possible de créer ou de modifier le title d'un espace de travail qui contient moins de 5 caractères.

Création :
Si l'on clique sur continuer sans mettre 5 minimum 5 caractères dans le title on ne peut rien valider.
<img width="945" height="976" alt="image" src="https://github.com/user-attachments/assets/4fbbd155-8e03-4338-bce8-70bbf484baca" />


Modification :
Si l'on souhaite modifier le title par un title de moins de 5 caractères on ne peut pas valider le changement.
<img width="945" height="424" alt="image" src="https://github.com/user-attachments/assets/1e1cffa7-5db6-4c33-8b1f-de921c2e70db" />
