### PR TITLE
0009425 - :sparkles: Faire une session de 8h si la case faire confiance à cet ordinateur n'est pas cochée

### DIFF
--- a/plugins/mel_ldap_auth/mel_ldap_auth.php
+++ b/plugins/mel_ldap_auth/mel_ldap_auth.php
@@ -265,6 +265,8 @@ class mel_ldap_auth extends rcube_plugin {
         $this->rc->output->send($this->rc->task);
       }
     }
+    if($_POST['_keeplogin'] === "keeplogin")
+      setcookie('keep_login', true);
     return $args;
   }
   /**


### PR DESCRIPTION
Depuis décembre 2025 la session Bnum est passée de 8h a 5j
Attention c'est une durée glissante.
Il faut (je propose) de revenir à 8h si la case faire confiance à cet ordinateur n'est pas cochée.
Cela n'a pas pu être discuté en cotech sso, mais je prends sur moi