### PR TITLE
0009462 - 🚑 Régression 26.3 : Le choix de la page d'accueil n'est pas appliqué, la connexion se fait sur task=mail

### DIFF
--- a/plugins/bnum/bnum.php
+++ b/plugins/bnum/bnum.php
@@ -27,8 +27,12 @@ class bnum extends bnum_plugin {
       $this->load_script_module('main', '/js/');
       }catch(Error $e) {}
     }
-    $this->add_hook('refresh', [$this, 'refresh']);
-    $this->add_hook('login_after', [$this, 'login_after']);
+
+    $this->add_hook('refresh', [$this, 'hook_refresh']);
+    $this->add_hook('logout_after', [$this, 'hook_logout_after']);
+
+    if ($this->is_bnum_task())
+      $this->register_action('plugin.bnum_after', [$this, 'action_after']);
   }
 
   /**
@@ -57,21 +61,39 @@ class bnum extends bnum_plugin {
   /**
    * Gestion du cookie once per day en php et JS
    */
-  public function refresh($args) {
+  public function hook_refresh($args) {
     if(!isset($_COOKIE['once_per_day'])) {
-
       setcookie('once_per_day', true, time()+60*60*24);
       $this->exec_hook('once_per_day');
 
       $this->rc()->output->command('plugin.local_once_per_day');
     }
+
+    return $args;
+  }
+
+  public function hook_logout_after($args) {
+
+    unset($_COOKIE['once_per_day']);
+    rcube_utils::setcookie('once_per_day', '-del-', time() - 60);
+    rcube_utils::setcookie('popup_msg_enrollment', '-del-', time() - 60);
+
+    return $args;
   }
 
   /**
    * Gestion lors de la première connexion pour ne pas doubler les actions au premier refresh
    */
-  public function login_after($args) { 
-    unset($_COOKIE['once_per_day']);
-    $this-> refresh($args);
+  public function action_after() { 
+    $valid = true;
+
+    try {
+      unset($_COOKIE['once_per_day']);
+      $this->hook_refresh([]);
+    } catch (\Throwable $th) {
+      $valid = $th;
+    }
+
+    $this->set_env('action_after.once_per_day_data', ['valid' => $valid === true, 'error' => $valid !== true ? $valid : null]);
   }
 }

--- a/plugins/bnum/bnum.php
+++ b/plugins/bnum/bnum.php
@@ -22,7 +22,9 @@ class bnum extends bnum_plugin {
     if (self::IsCalendarDriverForced()) self::UnforceCalendarDriver();
 
     $this->load_config();
-    if($_SERVER['REQUEST_METHOD'] === 'GET') {
+
+    $isLogged = $this->rc()->user->ID && $this->rc()->task !== 'login';
+    if($_SERVER['REQUEST_METHOD'] === 'GET' && $isLogged) {
       try {
       $this->load_script_module('main', '/js/');
       }catch(Error $e) {}

--- a/plugins/bnum/js/commands.js
+++ b/plugins/bnum/js/commands.js
@@ -1,10 +1,30 @@
 import { BnumLog } from '../../mel_metapage/js/lib/classes/bnum_log.js';
 import { MelObject } from '../../mel_metapage/js/lib/mel_object.js';
 
+//#region Types
+
 /**
- * Class qui enregistre et lance différentes commandes/triggers
+ * @typedef {Object} OncePerDayData
+ * @property {boolean} valid - Indique si la réponse PHP est valide
+ * @property {?Record<string, any>} error - Détails de l'erreur éventuelle
+ */
+
+//#endregion Types
+
+//#region Class principale
+
+/**
+ * Gère l'enregistrement et le déclenchement de commandes/triggers applicatifs.
+ *
+ * À l'instanciation, cette classe :
+ * - écoute l'événement `plugin.local_once_per_day` pour déclencher `once_per_day`
+ * - lance automatiquement la séquence post-login "once per day" si le contexte
+ *   est `bnum` et que le cookie correspondant est absent.
+ *
+ * @extends MelObject
  */
 export class Commands extends MelObject {
+  //#region Public
   constructor() {
     super();
 
@@ -12,37 +32,78 @@ export class Commands extends MelObject {
       this.#_oncePerDay();
     });
 
+    if (this.#_shouldFireOncePerDay()) this.#_startAfterLoginOncePerDay();
+  }
+  //#endregion Public
+
+  //#region Private
+
+  /**
+   * Détermine si la séquence "once per day" doit être déclenchée.
+   *
+   * Les deux conditions requises sont :
+   * 1. La tâche courante est `bnum` (contexte principal).
+   * 2. Le cookie `once_per_day` est absent (action non encore exécutée aujourd'hui).
+   *
+   * @returns {boolean} `true` si la séquence doit s'exécuter, `false` sinon.
+   */
+  #_shouldFireOncePerDay() {
     const isBnumTopContext = this.get_env('task') === 'bnum';
-    const alreadyFired = !this.cookie_get('once_per_day')?.value;
-    if (isBnumTopContext && alreadyFired) this.#_startArterLoginOncePerDay();
+    const cookieAbsent = !this.cookie_get('once_per_day')?.value;
+    return isBnumTopContext && cookieAbsent;
   }
 
   /**
-   * trigger évènement roundcube once_per_day
+   * Déclenche l'événement Roundcube `once_per_day`.
+   *
+   * @returns {void}
    */
   #_oncePerDay() {
     this.trigger('once_per_day');
   }
 
-  #_startArterLoginOncePerDay() {
-    return this.rcmail()
-      .http_post('plugin.bnum_after')
-      .then(() => {
-        this.#_startArterLoginOncePerDaySuccess(
-          this.get_env('action_after.once_per_day_data'),
-        );
-        this.rcmail().env['action_after.once_per_day_data'] = null;
-      });
+  /**
+   * Envoie la requête HTTP POST `plugin.bnum_after` après le login,
+   * puis traite la réponse ou logue l'erreur.
+   *
+   * @returns {Promise<void>}
+   */
+  async #_startAfterLoginOncePerDay() {
+    try {
+      await this.rcmail().http_post('plugin.bnum_after');
+
+      const rawData = this.get_env('action_after.once_per_day_data');
+      this.#_handleOncePerDayResponse(rawData);
+      this.rcmail().env['action_after.once_per_day_data'] = null;
+    } catch (err) {
+      BnumLog.error(
+        'PHP/plugin.bnum_after',
+        'Erreur lors de la requête post-login once_per_day.',
+        err,
+      );
+    }
   }
 
   /**
+   * Traite la réponse de la séquence post-login "once per day".
    *
-   * @param {{valid: boolean, error: ?Record<string, any>}} data
+   * Si `data.valid` est différent de `true`, l'erreur est loguée via {@link BnumLog}.
+   *
+   * @param {string | OncePerDayData} data - Données brutes (chaîne JSON ou objet).
+   * @returns {void}
    */
-  #_startArterLoginOncePerDaySuccess(data) {
-    if (typeof data === 'string') data = JSON.parse(data);
+  #_handleOncePerDayResponse(data) {
+    const parsed = typeof data === 'string' ? JSON.parse(data) : data;
 
-    if (data.valid !== true)
-      BnumLog.error('PHP/plugin.bnum_after', 'Une erreur est survenue !', data);
+    if (parsed.valid !== true) {
+      BnumLog.error(
+        'PHP/plugin.bnum_after',
+        'Une erreur est survenue !',
+        parsed,
+      );
+    }
   }
+  //#endregion Private
 }
+
+//#endregion Classe principale

--- a/plugins/bnum/js/commands.js
+++ b/plugins/bnum/js/commands.js
@@ -1,3 +1,4 @@
+import { BnumLog } from '../../mel_metapage/js/lib/classes/bnum_log.js';
 import { MelObject } from '../../mel_metapage/js/lib/mel_object.js';
 
 /**
@@ -10,6 +11,10 @@ export class Commands extends MelObject {
     this.listen('plugin.local_once_per_day', () => {
       this.#_oncePerDay();
     });
+
+    const isBnumTopContext = this.get_env('task') === 'bnum';
+    const alreadyFired = !this.cookie_get('once_per_day')?.value;
+    if (isBnumTopContext && alreadyFired) this.#_startArterLoginOncePerDay();
   }
 
   /**
@@ -17,5 +22,27 @@ export class Commands extends MelObject {
    */
   #_oncePerDay() {
     this.trigger('once_per_day');
+  }
+
+  #_startArterLoginOncePerDay() {
+    return this.rcmail()
+      .http_post('plugin.bnum_after')
+      .then(() => {
+        this.#_startArterLoginOncePerDaySuccess(
+          this.get_env('action_after.once_per_day_data'),
+        );
+        this.rcmail().env['action_after.once_per_day_data'] = null;
+      });
+  }
+
+  /**
+   *
+   * @param {{valid: boolean, error: ?Record<string, any>}} data
+   */
+  #_startArterLoginOncePerDaySuccess(data) {
+    if (typeof data === 'string') data = JSON.parse(data);
+
+    if (data.valid !== true)
+      BnumLog.error('PHP/plugin.bnum_after', 'Une erreur est survenue !', data);
   }
 }

--- a/plugins/mel/mel.php
+++ b/plugins/mel/mel.php
@@ -88,6 +88,7 @@ class mel extends rcube_plugin
     include_once __DIR__ . '/../../version.php';
     self::$VERSION .= " " . Version::VERSION;
     // Définition des hooks
+    $this->add_hook('login_after',          [$this, 'login_after']);
     $this->add_hook('user_create',          array($this, 'user_create'));
     $this->add_hook('m2_get_account',       array($this, 'm2_get_account'));
     $this->add_hook('smtp_connect',         array($this, 'smtp_connect'));
@@ -97,9 +98,9 @@ class mel extends rcube_plugin
     $this->add_hook('identities_list',      array($this, 'identities_list'));
     $this->add_hook('identity_update',      array($this, 'identity_update'));
     $this->add_hook('message_before_send',  array($this, 'message_before_send'));
-    $this->add_hook('imap_search_before', [$this, 'imap_search_before']);
-    $this->add_hook('once_per_day',           [$this, 'login_after']);
-    $this->add_hook('once_per_day',       [$this, 'unset_show_password_change']);
+    $this->add_hook('imap_search_before',   [$this, 'imap_search_before']);
+    $this->add_hook('once_per_day',         [$this, 'hook_oncePerDay']);
+    $this->add_hook('once_per_day',         [$this, 'unset_show_password_change']);
 
     // Template
     $this->add_hook('template_object_loginform',  array($this, 'login_form'));
@@ -474,10 +475,17 @@ class mel extends rcube_plugin
 
     $user = driver_mel::gi()->getUser();
 
-    if (!isset($user->dn)) {
-      return $args;
-    }
+    if (isset($user->dn)) $this->_updateUserIdentity();
 
+    return $args;
+  }
+
+  public function hook_oncePerDay($args) {
+    $this->_updateUserIdentity();
+    return $args;
+  }
+
+  private function _updateUserIdentity() {
     // Gestion des identities de l'utilisateur
     $rc_identities = $this->rc->user->list_identities();
     $m2_identities = $this->m2_list_identities();
@@ -520,7 +528,6 @@ class mel extends rcube_plugin
     foreach ($delete_identities as $delete_iid) {
       $this->rc->user->delete_identity($delete_iid);
     }
-    return $args;
   }
 
   /**

--- a/plugins/mel_doubleauth/mel_doubleauth.php
+++ b/plugins/mel_doubleauth/mel_doubleauth.php
@@ -339,8 +339,6 @@ class mel_doubleauth extends bnum_plugin
             && $this->rc->action == 'plugin.mel_doubleauth'
         ) {
 
-           rcube_utils::setcookie('popup_msg_enrollment', 'enrolled', time()+60*60*24);
-
             // add overlay input box to html page
             $this->rc->output->add_footer(
                 html::tag(
@@ -362,26 +360,18 @@ class mel_doubleauth extends bnum_plugin
     }
 
     public function hook_oncePerDay($args) {
-        if (isset($_COOKIE['popup_msg_enrollment'])) {
-            unset($_COOKIE['popup_msg_enrollment']);
-            rcube_utils::setcookie('popup_msg_enrollment', '-del-', time() - 60);
-            return;
-        }
-
         $config_2FA = $this->__get2FAconfig();
 
-        if (
-            !$config_2FA['activate']
-            && $this->rc->config->get('force_enrollment_users')
-            && $this->rc->task == 'settings'
-            && $this->rc->action == 'plugin.mel_doubleauth'
+        if ( $this->is_bnum_task() && 
+            !$config_2FA['activate'] && 
+             $this->rc->config->get('force_enrollment_users') 
+            // && $this->rc->task == 'settings'
+            // && $this->rc->action == 'plugin.mel_doubleauth'
         ) {
             try {
-                $this->rc()->output->add_script(
-                "$('#enrollment_dialog').show().dialog({ modal:true, resizable:false, closeOnEscape: true, width:420 });",
-                );
+                $this->rc()->output->command('plugin.force-start-da-modal');
             } catch (\Throwable $th) {
-                //throw $th;
+
             }
         }
 

--- a/plugins/mel_doubleauth/mel_doubleauth.php
+++ b/plugins/mel_doubleauth/mel_doubleauth.php
@@ -52,10 +52,11 @@ class mel_doubleauth extends bnum_plugin
 
         // hooks
         if (!$this->is_internal()) { // Connexion intranet => pas de double auth
+            $this->add_hook('login_after', [$this,'login_after']);
             $this->add_hook('logout_after', array($this, 'logout_after'));
             $this->add_hook('send_page', array($this, 'check_2FAlogin'));
             $this->add_hook('render_page', array($this, 'popup_msg_enrollment'));
-            $this->add_hook('once_per_day', [$this,'login_after']);
+            $this->add_hook('once_per_day', [$this,'hook_oncePerDay']);
         } else {
             // Si on est internal on considère qu'on s'est connecté avec la double auth (en cas de changement de VPN)
             $_SESSION['mel_doubleauth_login'] = time();
@@ -338,6 +339,8 @@ class mel_doubleauth extends bnum_plugin
             && $this->rc->action == 'plugin.mel_doubleauth'
         ) {
 
+           rcube_utils::setcookie('popup_msg_enrollment', 'enrolled', time()+60*60*24);
+
             // add overlay input box to html page
             $this->rc->output->add_footer(
                 html::tag(
@@ -356,6 +359,33 @@ class mel_doubleauth extends bnum_plugin
                 'docready'
             );
         }
+    }
+
+    public function hook_oncePerDay($args) {
+        if (isset($_COOKIE['popup_msg_enrollment'])) {
+            unset($_COOKIE['popup_msg_enrollment']);
+            rcube_utils::setcookie('popup_msg_enrollment', '-del-', time() - 60);
+            return;
+        }
+
+        $config_2FA = $this->__get2FAconfig();
+
+        if (
+            !$config_2FA['activate']
+            && $this->rc->config->get('force_enrollment_users')
+            && $this->rc->task == 'settings'
+            && $this->rc->action == 'plugin.mel_doubleauth'
+        ) {
+            try {
+                $this->rc()->output->add_script(
+                "$('#enrollment_dialog').show().dialog({ modal:true, resizable:false, closeOnEscape: true, width:420 });",
+                );
+            } catch (\Throwable $th) {
+                //throw $th;
+            }
+        }
+
+        return $args;
     }
 
     /**

--- a/plugins/mel_metapage/js/init/events.js
+++ b/plugins/mel_metapage/js/init/events.js
@@ -910,6 +910,13 @@ if (rcmail && window.mel_metapage) {
     else $('.ct-cm').css('display', 'none');
   });
 
+  rcmail.addEventListener('plugin.force-start-da-modal', function () {
+    rcmail.triggerEvent('start-da-modal', {
+      $input: $('#mail-da-input'),
+      $button: $('#start-button-modal'),
+    });
+  });
+
   rcmail.addEventListener('start-da-modal', async function (args) {
     const loader =
       window.loadJsModule ?? parent?.loadJsModule ?? top?.loadJsModule;


### PR DESCRIPTION
Séparation de la logique, on garde login_after tel quel, puis on extrait ce qui doit être fait une fois par jours, et on le met dans `once_per_day`.

Après le login, on appel l'action `plugin.bnum_after` via le javascript, seulement en context "top" et si le cookie `once_per_day` n'existe pas. 
(Voir schema récapitulatif)

<img width="1115" height="531" alt="image" src="https://github.com/user-attachments/assets/284ed2f1-e152-444b-ae96-ae72be0bff2c" />
