### PR TITLE
0009459 - :lipstick: Les petites flèches à côté des noms d'agenda ne se replient pas

### DIFF
--- a/skins/mel_elastic/styles/calendar.css
+++ b/skins/mel_elastic/styles/calendar.css
@@ -726,6 +726,9 @@ ul#calendarslist .calendar.focusview {
 ul#calendarslist li.selected > .calendar {
   cursor: default;
 }
+ul#calendarslist.treelist li div.treetoggle {
+  z-index: 1;
+}
 ul#calendarslist.treelist li div.treetoggle::before {
   margin-left: 6.5px;
 }

--- a/skins/mel_elastic/styles/less/calendar.less
+++ b/skins/mel_elastic/styles/less/calendar.less
@@ -1237,6 +1237,8 @@ ul {
       li {
         div {
           &.treetoggle {
+            z-index: 1;
+
             &::before {
               margin-left: 6.5px;
             }


### PR DESCRIPTION
Le bug venait d'un `z-index` qui a dût sauter.