### PR TITLE
0008554 - 🐛  La maj d'un evt d'un agenda non coché mais affiché avec l'œil n'est pas affiché dans le mode œil

### DIFF
--- a/plugins/calendar/calendar_ui.js
+++ b/plugins/calendar/calendar_ui.js
@@ -5141,6 +5141,10 @@ function rcube_calendar_ui(settings) {
           }
         }
 
+        if (!source.length && source) {
+          sources.push(source);
+        }
+
         fc.fullCalendar('refetchEventSources', sources);
       } else fc.fullCalendar('refetchEvents');
 


### PR DESCRIPTION
Il existe le cas ou la source n'est pas une source affichée mais est bien connue (l'oeil est coché mais pas l'agenda), il faut donc la rajouter dans les sources a rafraichir