### PR TITLE
0009181 - 🐛 Filtrage des mails selon les étiquettes: L'affichage des mails ayant une étiquette contenant un accent n'aboutit pas

### DIFF
--- a/plugins/mel_labels_sync/mel_label.js
+++ b/plugins/mel_labels_sync/mel_label.js
@@ -578,7 +578,10 @@ rcube_webmail.prototype.mel_label_show_tooltip = async function ($parent) {
         )
           .data(
             'value',
-            key.replace('_-s-_', '$').replace('_-t-_', '~').toUpperCase(),
+            key.replace('_-s-_', '$')
+                .replace('_-t-_', '~')
+                .replace('_-p-_', '.')
+                .replace('_-e-_', '&').toUpperCase(),
           )
           .text(element)
           .click((e) => {


### PR DESCRIPTION
Il manquait des conversions de caractères dans les filtres rapides