### PR TITLE
0009448 - 🐛 Changer la détection de lien dans les mails par la base de données

### DIFF
--- a/plugins/mel_metapage/mel_metapage.php
+++ b/plugins/mel_metapage/mel_metapage.php
@@ -391,7 +391,6 @@ class mel_metapage extends bnum_plugin
         $this->rc->output->set_env("matomo_tracking_popup", $this->rc->config->get("matomo_tracking_popup", false));
 
         $this->rc->output->set_env("mel_official_domain",  array_merge($this->rc->config->get("mel_official_domain", []), $this->rc->config->get('mel_user_domain', [])));
-        $this->rc->output->set_env("mel_suspect_url",  $this->rc->config->get("mel_suspect_url", []));
 
         //$this->rc->output->set_env("compose_extwin", true);
         $config = $this->rc->config->get("mel_metapage_chat_visible", true);

--- a/plugins/mel_suspects_urls/mel_suspects_urls.php
+++ b/plugins/mel_suspects_urls/mel_suspects_urls.php
@@ -23,6 +23,8 @@ class mel_suspects_urls extends bnum_plugin
     $this->setup_plugin()->setup_task()->setup_settings();
     $this->register_ajax_actions();
 
+    $this->add_urls_to_env();
+
     $this->add_hook('mel_urls_suspects_get_all', [$this, 'hook_get_all_urls']);
   }
 
@@ -435,6 +437,25 @@ class mel_suspects_urls extends bnum_plugin
     
     $args['urls'] = $urls;
     return $args;
+  }
+
+  /**
+   * Récupère toutes les URLs suspectes enregistrées en base de données pour les ajouter aux variables d'environnement pour la pop-up 
+   *
+   */
+  public function add_urls_to_env()
+  {
+    $rc = rcmail::get_instance();
+    $sql = "SELECT * FROM mel_suspects_urls";
+    $result = $this->db()->query($sql);
+
+    $urls = [];
+    while ($row = $this->db()->fetch_assoc($result)) {
+      $urls[] = $row['url'];
+    }
+    
+    //On ajoute en env pour la popup d'url suspecte
+    $rc->output->set_env("mel_suspect_url", $urls);
   }
 
   /**


### PR DESCRIPTION
	
Actuellement, la détection de lien de phishing utilise encore la config au lieu de la base de données