### PR TITLE
0009490 - :sparkles: Ajout d'un message d'erreur si code 2fa erroné

### DIFF
--- a/plugins/mel_doubleauth/localization/fr_FR.inc
+++ b/plugins/mel_doubleauth/localization/fr_FR.inc
@@ -72,6 +72,7 @@ $labels['check_code_to_activate'] = 'Pour sauvegarder vous devez valider un code
 $labels['logout_2fa_needed'] = "L'authentification à deux facteurs est obligatoire pour votre compte.";
 $labels['logout_2fa_needed_not_secure'] = "L'authentification à deux facteurs est obligatoire pour vous connecter depuis internet !";
 $labels['logout_2fa_needed_unknown'] = "Utilisateur incconnu !";
+$labels['logout_2fa_code_error'] = "Le code saisie est erroné.";
 
 // Messages used for the different portions of the plugin
 $messages = array();

--- a/plugins/mel_doubleauth/localization/fr_FR.inc
+++ b/plugins/mel_doubleauth/localization/fr_FR.inc
@@ -72,7 +72,7 @@ $labels['check_code_to_activate'] = 'Pour sauvegarder vous devez valider un code
 $labels['logout_2fa_needed'] = "L'authentification à deux facteurs est obligatoire pour votre compte.";
 $labels['logout_2fa_needed_not_secure'] = "L'authentification à deux facteurs est obligatoire pour vous connecter depuis internet !";
 $labels['logout_2fa_needed_unknown'] = "Utilisateur incconnu !";
-$labels['logout_2fa_code_error'] = "Le code saisie est erroné.";
+$labels['logout_2fa_code_error'] = "Le code saisi est erroné.";
 
 // Messages used for the different portions of the plugin
 $messages = array();

--- a/plugins/mel_doubleauth/mel_doubleauth.php
+++ b/plugins/mel_doubleauth/mel_doubleauth.php
@@ -243,9 +243,12 @@ class mel_doubleauth extends bnum_plugin
     public function logout_after($args)
     {
         $message = rcube_utils::get_input_value('_logout_msg', rcube_utils::INPUT_GET);
+        $da_logout_message = rcube_utils::get_input_value('_da_logout_message', rcube_utils::INPUT_GET);
 
         if (isset($message)) {
             $this->rc->output->show_message($message);
+        }
+        if ($da_logout_message == true) {
             $this->rc->output->set_env('da_logout_message', $message);
         }
 
@@ -295,7 +298,7 @@ class mel_doubleauth extends bnum_plugin
                     if (isset($url) && $url !== '') $this->__goingToUrl($url);
                     else $this->__goingRoundcubeTask($this->rc->config->get('default_task', 'mail'));
                 } else {
-                    $this->__exitSession();
+                   $this->__exitSession($this->gettext('logout_2fa_code_error'), false);
                 }
             }
             // we're into some task but marked with login...
@@ -794,13 +797,13 @@ class mel_doubleauth extends bnum_plugin
      * 
      * @param string $message
      */
-    private function __exitSession($message = null)
+    private function __exitSession($message = null, $da_logout_message = true)
     {
         unset($_SESSION['mel_doubleauth_login']);
         unset($_SESSION['mel_doubleauth_2FA_login']);
 
         if (isset($message)) {
-            header('Location: ?_task=logout&_logout_msg=' . $message . '&_token=' . $this->rc->get_request_token());
+            header('Location: ?_task=logout&_logout_msg=' . $message . '&_da_logout_message='.$da_logout_message.'&_token=' . $this->rc->get_request_token());
         } else {
             header('Location: ?_task=logout&_token=' . $this->rc->get_request_token());
         }


### PR DESCRIPTION
Actuellement, aucun message n'est affiché et une redirection est faite sur la page de login si le code de double auth rentré est erroné.

Rajouter un message indiquant "Le code saisi est erroné."
(le texte à été corrigé contrairement après la capture)
<img width="1445" height="532" alt="Capture d’écran du 2026-06-11 16-09-33" src="https://github.com/user-attachments/assets/d04d7469-c6e5-414f-b624-01d8dc0c4031" />
