### PR TITLE
0009209 - 🐛 supprimer un espace ne supprime pas la catégorie associée

### DIFF
--- a/plugins/mel_helper/lib/mel_utils.php
+++ b/plugins/mel_helper/lib/mel_utils.php
@@ -872,5 +872,37 @@ class mel_utils
     }
   }
 
+  /*
+  * Suppression d'une catégorie
+  */
+  public static function cal_remove_category($username, $name)
+  {
+      try {
+          $user = driver_mel::gi()->getUser($username);
+
+          if ($user === null || $user->is_external)
+              return false;
+
+          $categories = $user->getDefaultPreference("categories");
+          if (isset($categories)) {
+              $arr = array_filter(explode('|', $categories), function($c) use ($name) {
+                  return $c !== $name;
+              });
+              $user->saveDefaultPreference("categories", implode('|', $arr));
+          }
+
+          $colors = $user->getDefaultPreference("category_colors");
+          if (isset($colors)) {
+              $arr = array_filter(explode('|', $colors), function($c) use ($name) {
+                  return strpos($c, $name . ':') !== 0;
+              });
+              $user->saveDefaultPreference("category_colors", implode('|', $arr));
+          }
+
+          return true;
+      } catch (\Throwable $th) {
+          return false;
+      }
+  }
 
 }

--- a/plugins/mel_workspace/mel_workspace.php
+++ b/plugins/mel_workspace/mel_workspace.php
@@ -944,6 +944,15 @@ class mel_workspace extends bnum_plugin
         $uid = rcube_utils::get_input_value("_uid", rcube_utils::INPUT_POST);
         $workspace = self::Workspace($uid);
         if ($workspace->isAdmin()) {
+
+            // Suppression de la catégorie pour chaque utilisateur
+            if ($workspace->hasService(self::KEY_AGENDA)) {
+                mel_helper::load_helper()->include_utilities();
+                foreach ($workspace->users() as $s) {
+                    mel_utils::cal_remove_category($s->user, 'ws#' .$uid);
+                }
+            }
+
             $shares = $workspace->users();
             foreach ($shares as $key => $value) {
                 $this->delete_user($uid, $value->user, false, true);


### PR DESCRIPTION
Lorsque qu'un espace de travail est supprimée la catégorie associée l'est également pour tous les utilisateurs.

Modification de la fonction delete_workspace() et création d'une fonction cal_remove_category()