### PR TITLE
0009518 - :bug: Modal de confirmation à modifier

### DIFF
--- a/plugins/mel_doubleauth/mel_doubleauth.js
+++ b/plugins/mel_doubleauth/mel_doubleauth.js
@@ -6,13 +6,6 @@ if (window.rcmail) {
       rcmail.env.task == 'settings' &&
       rcmail.env.action == 'plugin.mel_doubleauth'
     ) {
-      window.onbeforeunload = function (e) {
-        if (!window.double_fact_saved) {
-          rcmail.http_request('plugin.mel_doubleauth-removeuser');
-          return "Attention! La configuration n'est pas terminée et l'authentification double facteur n'est pas encore activée, vous pouvez rester sur la page pour terminer la configuration ou quitter et laisse la double authentification désactivée.";
-        }
-      };
-
       rcmail.addEventListener(
         'responseafterplugin.mel_doubleauth-removeuser',
         function (evt) {


### PR DESCRIPTION
Si on ne terminais pas le process de la 2fa, mais qu'on réessayait ensuite, la 2fa n'était pas activer même si on avait finaliser le process.