### PR TITLE
0009194 - ✨ Proposer un détecteur de PJ manquante

### DIFF
--- a/plugins/mel_pj_detector/config.inc.php.sample
+++ b/plugins/mel_pj_detector/config.inc.php.sample
@@ -1,0 +1,35 @@
+<?php
+
+// PAMELA - 0009194 : détection pièce jointe manquante
+// Liste non exhaustive des mots-clés déclenchant l'alerte si aucune PJ n'est jointe au message
+$config['missing_attachment_keywords'] = [
+    // Français
+    'cf pj',
+    'cf. pj',
+    'ci-joint',
+    'ci joint',
+    'cijoint',
+    'document ci-joint',
+    'document joint',
+    'en pièce jointe',
+    'en piece jointe',
+    'en pj',
+    'fichier ci-joint',
+    'fichier joint',
+    'je joins',
+    'je vous joins',
+    'pièce jointe',
+    'piece jointe',
+    'pièces jointes',
+    'pieces jointes',
+    'tu trouveras ci-joint',
+    'veuillez trouver',
+    'voir pj',
+    'vous trouverez ci-joint',
+];
+
+// Rechercher aussi dans l'objet du message (true = oui, false = corps uniquement)
+$config['missing_attachment_check_subject'] = true;
+
+// Recherche des mots-clés sensible à la casse (false = insensible, recommandé)
+$config['missing_attachment_case_sensitive'] = false;

--- a/plugins/mel_pj_detector/js/lib/mel_pj_detector.js
+++ b/plugins/mel_pj_detector/js/lib/mel_pj_detector.js
@@ -1,0 +1,47 @@
+// PAMELA - 0009194 : détection pièce jointe manquante
+window.addEventListener('load', function() {
+
+  // Helper détection PJ manquante
+  rcmail._mentions_attachment = function(text) {
+    var keywords = this.env.missing_attachment_keywords || [],
+      case_sensitive = this.env.missing_attachment_case_sensitive || false,
+      haystack = case_sensitive ? text : text.toLowerCase();
+
+    for (var i = 0; i < keywords.length; i++) {
+      var needle = case_sensitive ? keywords[i] : keywords[i].toLowerCase();
+      if (needle && haystack.indexOf(needle) !== -1) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // Interception de l'envoi
+  rcmail.addEventListener('beforesend', function(props) {
+    var attachments = rcmail.env.attachments || {},
+      has_attachments = Object.keys(attachments).length > 0;
+
+    if (!has_attachments) {
+      var body_text = '';
+
+      if (window.tinyMCE && tinyMCE.get(rcmail.env.composebody)) {
+        body_text = tinyMCE.get(rcmail.env.composebody).getContent({ format: 'text' });
+      }
+      else {
+        var ta = document.getElementById(rcmail.env.composebody);
+          if (ta) body_text = ta.value || '';
+      }
+
+      if (rcmail.env.missing_attachment_check_subject) {
+        var subj = $("[name='_subject']").val() || '';
+        body_text += ' ' + subj;
+      }
+
+      if (rcmail._mentions_attachment(body_text)) {
+        if (!confirm(rcmail.get_label('missingattachmentconfirm', 'mel_pj_detector'))) {
+          return false;
+        }
+      }
+    }
+  });
+});

--- a/plugins/mel_pj_detector/js/lib/mel_pj_detector.js
+++ b/plugins/mel_pj_detector/js/lib/mel_pj_detector.js
@@ -3,12 +3,12 @@ window.addEventListener('load', function() {
 
   // Helper détection PJ manquante
   rcmail._mentions_attachment = function(text) {
-    var keywords = this.env.missing_attachment_keywords || [],
+    const keywords = this.env.missing_attachment_keywords || [],
       case_sensitive = this.env.missing_attachment_case_sensitive || false,
       haystack = case_sensitive ? text : text.toLowerCase();
 
-    for (var i = 0; i < keywords.length; i++) {
-      var needle = case_sensitive ? keywords[i] : keywords[i].toLowerCase();
+    for (let i = 0; i < keywords.length; i++) {
+      const needle = case_sensitive ? keywords[i] : keywords[i].toLowerCase();
       if (needle && haystack.indexOf(needle) !== -1) {
         return true;
       }
@@ -18,22 +18,22 @@ window.addEventListener('load', function() {
 
   // Interception de l'envoi
   rcmail.addEventListener('beforesend', function(props) {
-    var attachments = rcmail.env.attachments || {},
+    const attachments = rcmail.env.attachments || {},
       has_attachments = Object.keys(attachments).length > 0;
 
     if (!has_attachments) {
-      var body_text = '';
+      let body_text = '';
 
       if (window.tinyMCE && tinyMCE.get(rcmail.env.composebody)) {
         body_text = tinyMCE.get(rcmail.env.composebody).getContent({ format: 'text' });
       }
       else {
-        var ta = document.getElementById(rcmail.env.composebody);
+        const ta = document.getElementById(rcmail.env.composebody);
           if (ta) body_text = ta.value || '';
       }
 
       if (rcmail.env.missing_attachment_check_subject) {
-        var subj = $("[name='_subject']").val() || '';
+        const subj = $("[name='_subject']").val() || '';
         body_text += ' ' + subj;
       }
 

--- a/plugins/mel_pj_detector/js/lib/mel_pj_detector.js
+++ b/plugins/mel_pj_detector/js/lib/mel_pj_detector.js
@@ -17,7 +17,7 @@ window.addEventListener('load', function() {
   };
 
   // Interception de l'envoi
-  rcmail.addEventListener('beforesend', function(props) {
+  rcmail.addEventListener('beforesend', function() {
     const attachments = rcmail.env.attachments || {},
       has_attachments = Object.keys(attachments).length > 0;
 
@@ -33,7 +33,7 @@ window.addEventListener('load', function() {
       }
 
       if (rcmail.env.missing_attachment_check_subject) {
-        const subj = $("[name='_subject']").val() || '';
+        const subj = $('[name=\'_subject\']').val() || '';
         body_text += ' ' + subj;
       }
 

--- a/plugins/mel_pj_detector/localization/fr_FR.inc
+++ b/plugins/mel_pj_detector/localization/fr_FR.inc
@@ -1,0 +1,3 @@
+<?php
+
+$labels['missingattachmentconfirm'] = 'Votre message semble faire référence à une pièce jointe, mais aucun fichier n\'est joint.' . "\n\n" . 'Envoyer quand même ?';

--- a/plugins/mel_pj_detector/mel_pj_detector.php
+++ b/plugins/mel_pj_detector/mel_pj_detector.php
@@ -1,26 +1,56 @@
 <?php
 
+/**
+ * Plugin de détection de pièce jointe manquante.
+ *
+ * Affiche une alerte de confirmation à l'utilisateur lorsqu'il tente
+ * d'envoyer un message qui semble faire référence à une pièce jointe
+ * (via une liste de mots-clés configurable) mais qu'aucun fichier
+ * n'est réellement joint au message.
+ *
+ * La recherche des mots-clés s'effectue dans le corps du message et,
+ * optionnellement, dans l'objet. La liste des mots-clés, la prise en
+ * compte de l'objet et la sensibilité à la casse sont entièrement
+ * paramétrables via la config.
+ *
+ */
 class mel_pj_detector extends bnum_plugin
 {
     public $task = 'mail';
 
+    /**
+     * Initialise le plugin.
+     *
+     * Charge la configuration uniquement sur l'écran de composition
+     * d'un message (task=mail, action=compose), enregistre les textes
+     * de localisation, inclut le script JS de détection et transmet
+     * au client les paramètres nécessaires (mots-clés, options de
+     * recherche) via les variables d'environnement Roundcube.
+     *
+     * @return void
+     */
     public function init()
     {
-        $this->add_texts('localization/', true);
+        $this->load_config();
 
-        $this->rc()->output->set_env('missing_attachment_keywords',
-            $this->rc()->config->get('missing_attachment_keywords', [])
-        );
-        $this->rc()->output->set_env('missing_attachment_check_subject',
-            (bool) $this->rc()->config->get('missing_attachment_check_subject', false)
-        );
-        $this->rc()->output->set_env('missing_attachment_case_sensitive',
-            (bool) $this->rc()->config->get('missing_attachment_case_sensitive', false)
-        );
+        if ($this->rc()->task === 'mail' && $this->rc()->action === 'compose') {
+            $this->add_texts('localization/', true);
 
-        // Charge le JS uniquement en composition
-        if ($this->rc()->task === 'mail') {
             $this->include_script('js/lib/mel_pj_detector.js');
+
+            // Mots-clés et options depuis la config
+            $this->rc()->output->set_env('missing_attachment_keywords',
+                $this->rc()->config->get('missing_attachment_keywords', [])
+            );
+            $this->rc()->output->set_env('missing_attachment_check_subject',
+                (bool) $this->rc()->config->get('missing_attachment_check_subject')
+            );
+            $this->rc()->output->set_env('missing_attachment_case_sensitive',
+                (bool) $this->rc()->config->get('missing_attachment_case_sensitive')
+            );
+
+            // Label pour la pop-up de confirmation
+            $this->rc()->output->add_label('missingattachmentconfirm');
         }
     }
 }

--- a/plugins/mel_pj_detector/mel_pj_detector.php
+++ b/plugins/mel_pj_detector/mel_pj_detector.php
@@ -1,0 +1,26 @@
+<?php
+
+class mel_pj_detector extends bnum_plugin
+{
+    public $task = 'mail';
+
+    public function init()
+    {
+        $this->add_texts('localization/', true);
+
+        $this->rc()->output->set_env('missing_attachment_keywords',
+            $this->rc()->config->get('missing_attachment_keywords', [])
+        );
+        $this->rc()->output->set_env('missing_attachment_check_subject',
+            (bool) $this->rc()->config->get('missing_attachment_check_subject', false)
+        );
+        $this->rc()->output->set_env('missing_attachment_case_sensitive',
+            (bool) $this->rc()->config->get('missing_attachment_case_sensitive', false)
+        );
+
+        // Charge le JS uniquement en composition
+        if ($this->rc()->task === 'mail') {
+            $this->include_script('js/lib/mel_pj_detector.js');
+        }
+    }
+}


### PR DESCRIPTION
Comme préconisé, création d'un plugin dédié à la détection des PJ manquantes.

Lors de l'envoi d'un mail, si on fait référence à une pièce jointe dans le corps du message ou dans l'objet du message et que le message ne contient pas de pièce jointe une pop-up alerte l'utilisateur de l'éventuelle absence de pièce jointe et demande confirmation avant l'envoi du message.

<img width="1197" height="860" alt="19_06_2026_Image_Ticket_0009194_1" src="https://github.com/user-attachments/assets/493c91c4-19ce-47a4-af66-7456c3dd4829" />

La recherche de référence à une pièce jointe, ce fait par recherche de mots clés au travers d'une liste (non exhaustive) dans la config : conf-rcube>conf.template>config>config.inc.php.template
Il est également possible de configurer la recherche ou non dans l'objet du message et la sensibilité à la casse de la recherche des mots clés.