### PR TITLE
#509 - :bug: hide side bar menu on desktop

### DIFF
--- a/skins/mel_elastic/styles/taskbar.css
+++ b/skins/mel_elastic/styles/taskbar.css
@@ -646,11 +646,6 @@ html.touch #taskmenu a{
     border:none!important;
 }
 
-li#menu-small-li
-{
-    display: block!important;
-}
-
 /* #taskmenu a.selected {
 	pointer-events: none;
 } */


### PR DESCRIPTION
This pull request hides the menu icon on the desktop view, as shown in the screenshot below :
<img width="653" height="458" alt="image" src="https://github.com/user-attachments/assets/f85f3af9-a60f-4df7-a48f-2ea41c40b22f" />
