### PR TITLE
0009536 - 🐛  Désactiver la 2FA puis la réactiver dans la foulée pose problème

### DIFF
--- a/plugins/mel_doubleauth/mel_doubleauth.php
+++ b/plugins/mel_doubleauth/mel_doubleauth.php
@@ -413,23 +413,31 @@ class mel_doubleauth extends bnum_plugin
         $this->register_handler('plugin.body', array($this, 'mel_doubleauth_form'));
         $this->rc->output->set_pagetitle($this->gettext('mel_doubleauth'));
 
-        // POST variables
-        $activate = rcube_utils::get_input_value('p2FA_activate', rcube_utils::INPUT_POST);
-        $recovery_codes = (array)rcube_utils::get_input_value('2FA_recovery_codes', rcube_utils::INPUT_POST);
+        $this->exec_hook('plugin.mel_doubleauth.init', [
+            'rcmail' => $this->rc,
+            'plugin' => $this
+        ]);
 
-        // remove recovery codes without value
-        $recovery_codes = array_values(array_diff($recovery_codes, array('')));
+        // MANTIS 0009536: Désactiver la 2FA puis la réactiver dans la foulée pose problème
+        if (isset($_SERVER['REQUEST_METHOD']) && $_SERVER['REQUEST_METHOD'] == 'POST') {
+            // POST variables
+            $activate = rcube_utils::get_input_value('p2FA_activate', rcube_utils::INPUT_POST);
+            $recovery_codes = (array)rcube_utils::get_input_value('2FA_recovery_codes', rcube_utils::INPUT_POST);
 
-        $data = $this->__get2FAconfig();
-        $data['secret'] = null;
-        $data['activate'] = $activate ? true : false;
-        $data['recovery_codes'] = $recovery_codes;
-        $this->__set2FAconfig($data);
+            // remove recovery codes without value
+            $recovery_codes = array_values(array_diff($recovery_codes, array('')));
 
-        // if we can't save time into SESSION, the plugin logouts
-        $_SESSION['mel_doubleauth_2FA_login'] = time();
+            $data = $this->__get2FAconfig();
+            $data['secret'] = null;
+            $data['activate'] = $activate ? true : false;
+            $data['recovery_codes'] = $recovery_codes;
+            $this->__set2FAconfig($data);
 
-        $this->rc->output->show_message($this->gettext('successfully_saved'), 'confirmation');
+            // if we can't save time into SESSION, the plugin logouts
+            $_SESSION['mel_doubleauth_2FA_login'] = time();
+
+            $this->rc->output->show_message($this->gettext('successfully_saved'), 'confirmation');
+        }
 
         $this->rc->overwrite_action('plugin.mel_doubleauth');
         $this->rc->output->send('plugin');


### PR DESCRIPTION
Ne désactiver/activer la double auth que lors d'une requête POST