### PR TITLE
523- :bug: fix: prevent error when nextcloud is disabled

### DIFF
--- a/plugins/mel_metapage/js/init/classes/nextcloud/nextcloud.js
+++ b/plugins/mel_metapage/js/init/classes/nextcloud/nextcloud.js
@@ -381,5 +381,5 @@ Nextcloud.origin =
  * Récupère l'index, ex : /nextcloud/index.php
  */
 Nextcloud.getIndex = function () {
-  return this.index_url.replace(Nextcloud.origin, '');
+  return this.index_url?.replace(Nextcloud.origin, '');
 };


### PR DESCRIPTION
Lorsque le plugin Nextcloud est désactivé, mel_metapage tente tout de même d'utiliser Nextcloud.getIndex(). Comme rcmail.env.nextcloud_url n'est pas défini dans ce cas, un appel à replace() est effectué sur une valeur undefined, ce qui provoque une erreur JavaScript dans la console.

Le correctif consiste à vérifier que index_url est défini avant d'appeler replace(), afin d'éviter cette erreur lorsque Nextcloud n'est pas disponible.

**Étapes pour reproduire**
1. Désactiver le plugin Nextcloud dans Roundcube.
2. Ouvrir le webmail.
3. Ouvrir les outils de développement (Console).
4. Observer l'erreur JavaScript.

**Résultat observé**

Une erreur JavaScript est affichée dans la console.

<img width="989" height="102" alt="Image" src="https://github.com/user-attachments/assets/8f84d77e-2d1f-4c8d-adb1-12a9f3884c36" />

**Résultat attendu**

Aucune erreur JavaScript ne doit être générée lorsque le plugin Nextcloud est désactivé.