### PR TITLE
dsfr-bnum - 🎨 Modification du bouton qui permet d'ouvrir ou de fermer la barre de navigation d'un espace de travail

### DIFF
--- a/plugins/mel_workspace/js/lib/WebComponents/navbar.js
+++ b/plugins/mel_workspace/js/lib/WebComponents/navbar.js
@@ -3,6 +3,7 @@ import { HTMLBnumButton } from '../../../../../skins/mel_elastic/design-system/d
 import { HTMLBnumPrimaryButton } from '../../../../../skins/mel_elastic/design-system/ds-module-bnum.js';
 import { HTMLBnumToggleButton } from '../../../../../skins/mel_elastic/design-system/ds-module-bnum.js';
 import { HTMLBnumDangerButton } from '../../../../../skins/mel_elastic/design-system/ds-module-bnum.js';
+import { HTMLBnumButtonIcon } from '../../../../../skins/mel_elastic/design-system/ds-module-bnum.js';
 import { EMPTY_STRING } from '../../../../mel_metapage/js/lib/constants/constants.js';
 import { BnumModules } from '../../../../mel_metapage/js/lib/helpers/dynamic_load_modules.js';
 import {
@@ -329,34 +330,28 @@ class WspNavBar extends HtmlCustomTag {
     return this;
   }
 
-  /**
-   * Génère le bouton permettant de réduire/étendre la barre de navigation
-   * et bascule la classe `minified` sur le composant selon son état.
-   * @returns {WspNavBar} L'instance courante, pour chaînage.
-   */
+  // /**
+  //  * Génère le bouton permettant de réduire/étendre la barre de navigation
+  //  * et bascule la classe `minified` sur le composant selon son état.
+  //  * @returns {WspNavBar} L'instance courante, pour chaînage.
+  //  */
   _generate_minify_button() {
-    const button = HTMLBnumToggleButton.Create({
-      variation: 'secondary',
-      iconMargin: '0',
-      icon: 'keyboard_double_arrow_left',
-      rounded: true,
-    }).attr('id', 'wsp-nav-minify-expand');
+    const button = HTMLBnumButtonIcon.Create('left_panel_close');
+    button.id = 'wsp-nav-minify-expand';
+    button.setAttribute('slot', 'actions');
+    button.title = rcmail.get_label('mel_workspace.minify_nav');
 
-    button.onpressedchange.push((pressed) => {
-      if (pressed) {
+    button.addEventListener('click', () => {
+      const minified = this.classList.contains('minified');
+
+      if (!minified) {
         this.addClass('minified');
-        button.icon = 'keyboard_double_arrow_right';
-        button.setAttribute(
-          'title',
-          "Maximiser la barre de navigation de l'espace.",
-        );
+        button.icon = 'left_panel_open';
+        button.title = rcmail.get_label('mel_workspace.expand_nav');
       } else {
         this.removeClass('minified');
-        button.icon = 'keyboard_double_arrow_left';
-        button.setAttribute(
-          'title',
-          "Minimiser la barre de navigation de l'espace.",
-        );
+        button.icon = 'left_panel_close';
+        button.title = rcmail.get_label('mel_workspace.minify_nav');
       }
     });
 

--- a/plugins/mel_workspace/localization/fr_FR.inc
+++ b/plugins/mel_workspace/localization/fr_FR.inc
@@ -11,3 +11,6 @@ $labels['see_all'] = 'Voir tout';
 $labels['workspace_title_min_length'] = 'Le titre de l\'espace de travail doit contenir au minimum %d caractères.';
 $labels['workspace_title_invalid_first_char'] = 'Le titre de l\'espace de travail doit commencer par une lettre ou un chiffre.';
 $labels['workspace_title_title'] = 'Le titre doit contenir au minimum %d caractères et commencer par une lettre ou un chiffre.';
+
+$labels['minify_nav'] = 'Minimiser la barre de navigation de l\'espace.';
+$labels['expand_nav'] = 'Maximiser la barre de navigation de l\'espace.';


### PR DESCRIPTION
En reprenant le style des autres icones présentent dans le header des espaces de travail :

<img width="354" height="57" alt="image" src="https://github.com/user-attachments/assets/00313c36-46ed-41bf-9fab-93e95b9796b7" />

Modification du bouton qui permet d'ouvrir ou de fermer la barre de navigation de gauche d'un espace de travail :

**Ancienne version :**
<img width="474" height="1059" alt="image" src="https://github.com/user-attachments/assets/87c7e20a-9c93-47e2-a1e5-45efaf2193e0" />

**Nouvelle version :**
<img width="483" height="1061" alt="image" src="https://github.com/user-attachments/assets/6e79edc2-ce7d-41fa-bb8e-37017f6c0289" />