### PR TITLE
recette - 0009294 - 🐛 erreur 500 lors de l'enregistrement de la sauvegarde de chgt d'agenda dans un evt

### DIFF
--- a/plugins/calendar/drivers/mel/mel_driver.php
+++ b/plugins/calendar/drivers/mel/mel_driver.php
@@ -1129,7 +1129,7 @@ class mel_driver extends calendar_driver {
 
     // Utilise la méthode move() de l'ORM
     // Elle gère la copie, l'organisateur et la suppression de l'ancien événement
-    $_event->move($from_id);
+    $_event->move($from_id, $this->user);
 
     // Invalider les ctags
     $this->calendars[$from_id]->getCTag(false);


### PR DESCRIPTION
Un seul argument passé à move() alors que 2 étaient attendus, ce qui provoquait l'erreur 500 Internal server error.

Dans les logs errors on obtenait :

`[30-Jul-2026 09:03:19 UTC] PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function LibMelanie\Api\Defaut\Event::move(), 1 passed in /opt/bnum/rcube/github/Roundcube-plugins-Mel/plugins/calendar/drivers/mel/mel_driver.php on line 1132 and exactly 2 expected in /opt/bnum/orm/gitlab-forge/sources-orm/src/Api/Defaut/Event.php:2163`
