### PR TITLE
0009068 - 🐛 Modification des images lors de la création d'un article non prises en compte

### DIFF
--- a/plugins/mel_forum/mel_forum.php
+++ b/plugins/mel_forum/mel_forum.php
@@ -1932,7 +1932,8 @@ class mel_forum extends bnum_plugin
                     $usedImageUids[] = $imageUid;
 
                     // Remplacer la balise <img> par celle avec l'URL
-                    $content = str_replace($img[0], '<img src="' . $imageUrl . '" />', $content);
+                    $newTag = str_replace('src="' . $src . '"', 'src="' . $imageUrl . '"', $img[0]);
+                    $content = str_replace($img[0], $newTag, $content);
                 }
             }
         }


### PR DESCRIPTION
Lors de la création d'un nouvel article conserver la mise en forme des images (redimensionnement, centrage, ...) lors de la publication de l'article comme c'est le cas dans la modification  des articles.