### PR TITLE
0009234 - ✨ EDT PUBLIC: Faire en sorte que la rédaction des articles se fasse par les admin du salon

### DIFF
--- a/plugins/mel_forum/js/lib/forum.js
+++ b/plugins/mel_forum/js/lib/forum.js
@@ -793,7 +793,7 @@ export class Forum extends MelObject {
       },
       processData: false,
       contentType: false,
-      on_success: (response) => {
+      on_success: () => {
         let like_div = $('#add_like-' + post_uid);
         let dislike_div = $('#add_dislike-' + post_uid);
         let like_counter = like_div.find('span.ml-2');
@@ -830,7 +830,7 @@ export class Forum extends MelObject {
         }
         this.rcmail().triggerEvent('forum.new_post.updated');
       },
-      on_error: (err) => {
+      on_error: () => {
         BnumMessage.DisplayMessage(
           rcmail.gettext('mel_forum.error_editing'),
           eMessageType.Error,

--- a/plugins/mel_forum/js/lib/forum.js
+++ b/plugins/mel_forum/js/lib/forum.js
@@ -46,6 +46,13 @@ export class Forum extends MelObject {
   initButtons() {
     //bouton d'ajout d'article
     $('#forum-button-add').click(() => {
+      if (!this.get_env('can_write_article')) {
+        BnumMessage.DisplayMessage(
+          rcmail.gettext('mel_forum.admin_only_publish'),
+          eMessageType.Error,
+        );
+        return;
+      }
       window.location.href = this.url('forum', {
         action: 'create_or_edit_post',
         params: { _workspace_uid: this.workspace },

--- a/plugins/mel_forum/localization/fr_FR.inc
+++ b/plugins/mel_forum/localization/fr_FR.inc
@@ -69,6 +69,7 @@ $labels['view_history'] = 'Historique';
 
 $labels['admin_edit_only'] = 'Autoriser uniquement les administrateurs de l\'espace à modifier l\'article';
 $labels['enable_comments'] = 'Autoriser la publication de commentaires';
+$labels['admin_only_publish'] = 'Seuls les administrateurs peuvent publier dans ce salon.';
 
 #endregion
 #region Bouton et Action

--- a/plugins/mel_forum/mel_forum.php
+++ b/plugins/mel_forum/mel_forum.php
@@ -143,6 +143,7 @@ class mel_forum extends bnum_plugin
             'workspace_uid' => $workspace_uid,
             'user_fullname' => driver_mel::gi()->getUser()->name,
             'is_admin' => driver_mel::gi()->getUser()->isWorkspaceOwner($workspace_uid),
+            'can_write_article' => $this->_can_write_article($workspace_uid),
             'wsp_tags' => $this->_get_all_tags_by_workspace($workspace_uid),
         ]);
 
@@ -386,10 +387,17 @@ class mel_forum extends bnum_plugin
         $uid = $this->get_input('_uid', rcube_utils::INPUT_GET);
         // Récupérer l'utilisateur
         $user = driver_mel::gi()->getUser();
+        $workspace_uid = $this->get_input('_workspace_uid');
 
         //vérification des droits d'accès
-        if ($user->isWorkspaceMember($this->get_input('_workspace_uid'))) {
-            $this->rc()->output->set_env('wsp_tags', $this->_get_all_tags_by_workspace($this->get_input('_workspace_uid')));
+        if ($user->isWorkspaceMember($workspace_uid)) {
+            // Dans un espace public, seul les admins de l'espace peuvent rédiger un nouvel article
+            if (!$uid && !$this->_can_write_article($workspace_uid)) {
+                $this->_display_error_page();
+                exit;
+            }
+
+            $this->rc()->output->set_env('wsp_tags', $this->_get_all_tags_by_workspace($workspace_uid));
             $this->rc()->html_editor();
             $this->load_script_module('create_or_edit_post');
 
@@ -958,7 +966,12 @@ class mel_forum extends bnum_plugin
         //charge l'article en bdd
         $post = new LibMelanie\Api\Defaut\Posts\Post();
         $post->uid = $uid;
-        $post->load();
+        $post_exists = $post->load();
+
+        // Dans un espace public, seuls les admin de l'espace peuvent créer un nouvel article
+        if (!$post_exists && !$this->_can_write_article($workspace_uid)) {
+            return null;
+        }
 
         // Section miniature
         $settings = json_decode($settings);
@@ -3323,6 +3336,22 @@ class mel_forum extends bnum_plugin
             $return = true;
 
         return $return;
+    }
+
+    /**
+     * Seuls les admins d'un espace de travail public peuvent rédiger des articles.
+     *
+     * @param string $workspace_uid Workspace
+     *
+     * @return boolean
+     */
+    protected function _can_write_article($workspace_uid)
+    {
+        if (mel_workspace::Workspace($workspace_uid)->isPublic()) {
+            return driver_mel::gi()->getUser()->isWorkspaceOwner($workspace_uid);
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Lorsque qu'une personne qui n'est pas admin souhaite ajouter un article dans un espace de travail public, un message l'informe que "Seuls les administrateurs peuvent publier dans ce salon".

<img width="945" height="483" alt="image" src="https://github.com/user-attachments/assets/de92eca9-743d-4de3-bfc1-b68632f9a311" />
