### PR TITLE
0009560 - :bug: Le texte de la sélection d'étiquette n'est pas visible

### DIFF
--- a/plugins/mel_labels_sync/mel_label.js
+++ b/plugins/mel_labels_sync/mel_label.js
@@ -583,15 +583,15 @@ rcube_webmail.prototype.mel_label_show_tooltip = async function ($parent) {
       element = rcmail.env.labels_translate[key];
 
       $ul.append(
-        $(
-          '<button type="button" class="btn true"></button>',
-        )
+        $('<button type="button" class="btn true"></button>')
           .data(
             'value',
-            key.replace('_-s-_', '$')
-                .replace('_-t-_', '~')
-                .replace('_-p-_', '.')
-                .replace('_-e-_', '&').toUpperCase(),
+            key
+              .replace('_-s-_', '$')
+              .replace('_-t-_', '~')
+              .replace('_-p-_', '.')
+              .replace('_-e-_', '&')
+              .toUpperCase(),
           )
           .text(element)
           .click((e) => {
@@ -844,7 +844,7 @@ $(document).ready(function () {
       css += '.toolbarmenu li.label_' + id + ' a.active,\n';
       css += 'table span.label_' + id + '\n';
       css += '{\n';
-      css += '  color: ' + val + ';\n';
+      css += '  color: ' + textcolor + ';\n';
       css += '}\n';
       css += `#messagelist tr.label_${id} td.labels span.text_label_${id} {
 				color:${textcolor};


### PR DESCRIPTION
On mettais la couleur du bg au lieu du texte

Avant : 
<img width="236" height="549" alt="image" src="https://github.com/user-attachments/assets/4550459a-9fb4-4fd4-9c63-deeb4f54b171" />
Après :
<img width="211" height="418" alt="image" src="https://github.com/user-attachments/assets/c03eb083-edac-49fe-972f-d2a545345b9e" />
