### PR TITLE
0009566 - 🐛 sur mobile pas de menu pour déplacer les mails

### DIFF
--- a/plugins/mel_metapage/js/lib/mel_object.js
+++ b/plugins/mel_metapage/js/lib/mel_object.js
@@ -333,6 +333,26 @@ class MelObject extends ABaseMelObject {
   }
 
   /**
+   * Vérifie si l'interface est actuellement affichée en mode tactile
+   * (téléphone) ou en petit écran.
+   *
+   * @returns {boolean} `true` si le layout est en mode téléphone ou petit écran
+   *
+   * @example
+   * if (this.isLayoutSmallOfPhone()) {
+   *   // Simplifie l'UI pour un affichage mobile
+   * }
+   */
+  isLayoutSmallOfPhone() {
+    const html = document.querySelector('html');
+
+    return (
+      html.classList.contains('layout-phone') ||
+      html.classList.contains('layout-small')
+    );
+  }
+
+  /**
    * Envoie un MelObject vide.
    * @returns {EmptyMelObject}
    * @static

--- a/skins/mel_elastic/design-system/bridges/BridgeMail.js
+++ b/skins/mel_elastic/design-system/bridges/BridgeMail.js
@@ -217,6 +217,23 @@ export default class BridgeMail extends ABridge {
   _p_onInit() {
     if (!this.rcmail()) return this;
     if (!window.bridgeMail) this.export('bridgeMail', this);
+    
+    // Sur mobile, éviter l'ouverture automatique du mail sélectionné.
+    if (
+      $('html').hasClass('layout-phone') ||
+      $('html').hasClass('layout-small')
+    ) {
+      const original_preview = this.rcmail().msglist_get_preview;
+      this.rcmail().msglist_get_preview = function () {
+        if (
+          $('html').hasClass('layout-phone') ||
+          $('html').hasClass('layout-small')
+        ) {
+          return;
+        }
+        return original_preview.apply(this, arguments);
+      };
+    }
 
     return this.#initMail();
   }
@@ -566,6 +583,9 @@ export default class BridgeMail extends ABridge {
   #decorateRow(row) {
     this.#hideMsgIcon(row);
     this.#addUtilityClass(row);
+    // La case à cocher native n'était jamais exclue de l'interception de clic
+    // de la ligne : la cocher ouvrait le mail en plus de le sélectionner.
+    this.#ignoreCapture(row.querySelector('.selection input'));
 
     const avatarContainer = this.#buildAvatarContainer(row);
     const rowActions = this.#buildRowActions(row);
@@ -664,26 +684,32 @@ export default class BridgeMail extends ABridge {
       ?.attr?.('id', `action-of-${row.id}`)
       ?.addClass?.('mail-avatar--action');
 
-    action.addEventListener(
-      'click',
-      (e) => {
-        e.stopImmediatePropagation();
-        e.stopPropagation();
-        e.preventDefault();
+    /**
+     * Sélectionne/désélectionne la ligne. Rattaché à `action` (bouton révélé
+     * au survol sur desktop) et à `avatarContainer` (seule zone atteignable
+     * au doigt sur mobile, où le survol ne se déclenche jamais).
+     */
+    const selectRow = (e) => {
+       e.stopImmediatePropagation();
+       e.stopPropagation();
+       e.preventDefault();
+ 
+       const selectionBtn = document.querySelector(`#${row.id} .selection`);
+       if (!selectionBtn) {
+         console.error(
+           `[BridgeMail] Bouton .selection introuvable dans #${row.id}`,
+         );
+         return;
+       }
+ 
+      action.icon = this.#getSelectionIcon(row.id, { inverted: true });
+       this.rcmail().dummy_select = true;
+       this.#ignoreCapture(selectionBtn).click();
+       this.rcmail().dummy_select = null;
+      clearTimeout(this.rcmail().preview_timer);
+     };
 
-        const selectionBtn = document.querySelector(`#${row.id} .selection`);
-        if (!selectionBtn) {
-          console.error(
-            `[BridgeMail] Bouton .selection introuvable dans #${row.id}`,
-          );
-          return;
-        }
-
-        action.icon = this.#getSelectionIcon(row.id, { inverted: true });
-        this.#ignoreCapture(selectionBtn).click();
-      },
-      true,
-    );
+    action.addEventListener('click', selectRow, true);
 
     const avatarContainer = HTMLBnumAvatarAction.Create({ avatar, action });
     avatarContainer
@@ -698,6 +724,10 @@ export default class BridgeMail extends ABridge {
           console.error(`[BridgeMail] Élément action-of-${rowId} introuvable.`);
         }
       });
+
+    avatarContainer.addEventListener('click', selectRow, true);
+    this.#ignoreCapture(avatarContainer);
+    this.#ignoreCapture(avatar);
 
     return avatarContainer;
   }

--- a/skins/mel_elastic/design-system/bridges/BridgeMail.js
+++ b/skins/mel_elastic/design-system/bridges/BridgeMail.js
@@ -3,6 +3,7 @@ import { BnumLog } from '../../../../plugins/mel_metapage/js/lib/classes/bnum_lo
 import { MelEnumerable } from '../../../../plugins/mel_metapage/js/lib/classes/enum.js';
 import { EMPTY_STRING } from '../../../../plugins/mel_metapage/js/lib/constants/constants.js';
 import { AvatarElement } from '../../../../plugins/mel_metapage/js/lib/html/JsHtml/CustomAttributes/avatar.js';
+import { MelObject } from '../../../../plugins/mel_metapage/js/lib/mel_object.js';
 import {
   DsCssProperty,
   DsCssRule,
@@ -217,18 +218,12 @@ export default class BridgeMail extends ABridge {
   _p_onInit() {
     if (!this.rcmail()) return this;
     if (!window.bridgeMail) this.export('bridgeMail', this);
-    
+
     // Sur mobile, éviter l'ouverture automatique du mail sélectionné.
-    if (
-      $('html').hasClass('layout-phone') ||
-      $('html').hasClass('layout-small')
-    ) {
+    if (this.isLayoutSmallOfPhone()) {
       const original_preview = this.rcmail().msglist_get_preview;
       this.rcmail().msglist_get_preview = function () {
-        if (
-          $('html').hasClass('layout-phone') ||
-          $('html').hasClass('layout-small')
-        ) {
+        if (MelObject.Empty().isLayoutSmallOfPhone()) {
           return;
         }
         return original_preview.apply(this, arguments);
@@ -690,24 +685,24 @@ export default class BridgeMail extends ABridge {
      * au doigt sur mobile, où le survol ne se déclenche jamais).
      */
     const selectRow = (e) => {
-       e.stopImmediatePropagation();
-       e.stopPropagation();
-       e.preventDefault();
- 
-       const selectionBtn = document.querySelector(`#${row.id} .selection`);
-       if (!selectionBtn) {
-         console.error(
-           `[BridgeMail] Bouton .selection introuvable dans #${row.id}`,
-         );
-         return;
-       }
- 
+      e.stopImmediatePropagation();
+      e.stopPropagation();
+      e.preventDefault();
+
+      const selectionBtn = document.querySelector(`#${row.id} .selection`);
+      if (!selectionBtn) {
+        console.error(
+          `[BridgeMail] Bouton .selection introuvable dans #${row.id}`,
+        );
+        return;
+      }
+
       action.icon = this.#getSelectionIcon(row.id, { inverted: true });
-       this.rcmail().dummy_select = true;
-       this.#ignoreCapture(selectionBtn).click();
-       this.rcmail().dummy_select = null;
+      this.rcmail().dummy_select = true;
+      this.#ignoreCapture(selectionBtn).click();
+      this.rcmail().dummy_select = null;
       clearTimeout(this.rcmail().preview_timer);
-     };
+    };
 
     action.addEventListener('click', selectRow, true);
 

--- a/skins/mel_elastic/design-system/bridges/BridgeRc.js
+++ b/skins/mel_elastic/design-system/bridges/BridgeRc.js
@@ -290,7 +290,7 @@ export default class BridgeRc extends MelObject {
 
         fire(async () => {
           if (popover) {
-            await this.wait_something(() => popover.style.transform !== null);
+            await this.wait_something(() => !!popover.style.transform);
             popover.style.transform = null;
           }
         });

--- a/skins/mel_elastic/design-system/bridges/BridgeRc.js
+++ b/skins/mel_elastic/design-system/bridges/BridgeRc.js
@@ -235,4 +235,66 @@ export default class BridgeRc extends MelObject {
 
     this.#_attachFolderListeners(el, folderMenu);
   }
+
+  /**
+   * Patch : conserve le comportement natif du sélecteur de dossier (bouton
+   * "Déplacer" de la liste des messages), puis corrige un décalage visuel du
+   * popover qui s'affiche à côté. Roundcube laisse une `transform` CSS sur ce
+   * popover après son ouverture initiale ; on attend qu'il soit référencé par
+   * le bouton (`aria-describedby`) puis on retire cette transformation une
+   * fois le rendu stabilisé. Ignoré sur écran normal ou plus grand, où ce popover
+   * fonctionne correctement.
+   *
+   * @param {Object} target - Instance Roundcube sur laquelle la méthode d'origine est appelée
+   * @param {AnyFunction} oldFn - Méthode `folder_selector` d'origine de Roundcube
+   * @param {...any} args - Arguments transmis à la méthode d'origine
+   * @returns {Promise<void>}
+   */
+  async patch_folder_selector(target, oldFn, ...args) {
+    oldFn.call(target, ...args);
+
+    if (!this.isLayoutSmallOfPhone()) return;
+
+    /**
+     * Reporte `callback` après le microtask courant, en visant le prochain
+     * repaint via `requestAnimationFrame`.
+     *
+     * @param {Function} callback
+     */
+    const addInQueue = (callback) => {
+      queueMicrotask(() => {
+        requestAnimationFrame(callback);
+      });
+    };
+
+    /**
+     * Exécute `callback` après un délai, pour laisser le popover se stabiliser
+     * avant de lui retirer sa `transform`.
+     *
+     * @param {Function} callback
+     * @param {number} [timeout=200] - Délai en millisecondes avant exécution
+     */
+    const fire = (callback, timeout = 200) => {
+      setTimeout(callback, timeout);
+    };
+
+    const element = document.querySelector('#messagelist-header a.move');
+
+    await this.wait_something(() => element.hasAttribute('aria-describedby'));
+
+    addInQueue(() => {
+      if (element.hasAttribute('aria-describedby')) {
+        const popover = document.getElementById(
+          element.getAttribute('aria-describedby'),
+        );
+
+        fire(async () => {
+          if (popover) {
+            await this.wait_something(() => popover.style.transform !== null);
+            popover.style.transform = null;
+          }
+        });
+      }
+    });
+  }
 }

--- a/skins/mel_elastic/styles/parts/less/mails.less
+++ b/skins/mel_elastic/styles/parts/less/mails.less
@@ -506,6 +506,10 @@ html.layout-small {
       bottom: 0;
     }
   }
+
+  .popover:not(.select-menu) {
+    transform: unset !important;
+  }
 }
 
 #searchmenu .formcontent {

--- a/skins/mel_elastic/styles/parts/mails.css
+++ b/skins/mel_elastic/styles/parts/mails.css
@@ -293,6 +293,10 @@ html.layout-small .task-mail #layout-content > div.footer {
   border-top: var(--bnum-border-in-surface);
   bottom: 0;
 }
+html.layout-phone .popover:not(.select-menu),
+html.layout-small .popover:not(.select-menu) {
+  transform: unset !important;
+}
 #searchmenu .formcontent {
   color: var(--bnum-text-primary);
 }


### PR DESCRIPTION
<img width="399" height="795" alt="image" src="https://github.com/user-attachments/assets/1bb31c4b-c6ce-4805-8941-8bf45f2793ea" />

Il fallait neutraliser l'ouverture automatique du mail et éviter que le clic sur l'avatar qui cache à la case à cocher pour sélectionner un email provoque l'ouverture du mail et donc court circuit l'accès à "Déplacer vers ...."