### PR TITLE
0009572 - :ambulance: Malgré la coche faire confiance cochée la session reste de 8h et pas de 5j comme attendue

### DIFF
--- a/plugins/mel_ldap_auth/mel_ldap_auth.php
+++ b/plugins/mel_ldap_auth/mel_ldap_auth.php
@@ -265,8 +265,10 @@ class mel_ldap_auth extends rcube_plugin {
         $this->rc->output->send($this->rc->task);
       }
     }
-    if($_POST['_keeplogin'] === "keeplogin")
-      setcookie('keep_login', true);
+    if ($_POST['_keeplogin'] === "keeplogin") {
+      $lifetime = $this->rc->config->get('session_lifetime', 0) * 60;
+      rcube_utils::setcookie('keep_login', true, $lifetime ? time() + $lifetime * 100 : 0);
+    }
     return $args;
   }
   /**


### PR DESCRIPTION
>setcookie('keep_login', true);
>C'est a dire 0, durée session.
>Hors la durée session sur mobile est vraiment de durée session (alors que sur PC c'est "infini") Il faut mettre la même durée que roundcube_sessid et roundcube_sessauth
>Si c'est compliqué mettre au moins 1 an.

On se base désormait sur les même calculs que roundcube.