### PR TITLE
0009575 - :bug: Sur smartphone : le retour sur la BAL actuelle de fonctionne pas lorsque qu'on revient à la liste des bals

### DIFF
--- a/skins/mel_elastic/ui.js
+++ b/skins/mel_elastic/ui.js
@@ -4399,3 +4399,57 @@ $(document).ready(() => {
     console.error('### [BNUM]MEL_ELASTIC_UI : ', error);
   }
 });
+
+const PATCH_ENABLED = true;
+
+if (PATCH_ENABLED) {
+  /**
+   * Corrige un défaut du cœur Roundcube (skins/elastic/ui.js, non modifiable) :
+   * au chargement de la page, `layout_init()` cherche le panneau initialement
+   * sélectionné avec le sélecteur `#layout > div.selected`, restreint au tag
+   * `<div>`. Dans ce skin, `#layout-sidebar` et `#layout-list` sont des
+   * `<bnum-column>` : ce sélecteur ne matche donc jamais rien, et le cœur
+   * retombe sur son fallback, qui prend le premier panneau existant dans
+   * l'ordre ['sidebar', 'list', 'content'] — toujours la sidebar, même quand
+   * c'est la liste des mails qui est réellement affichée à l'écran.
+   *
+   * Cette valeur figée est capturée une seule fois par `content_frame_init()`
+   * puis réappliquée par le cœur après chaque navigation de l'iframe de
+   * contenu vers la page blanche (ex. retour depuis un mail affiché sur
+   * mobile), ce qui écrase la bonne valeur posée juste avant par
+   * `hide_content()` et affiche la liste des dossiers au lieu de la liste des
+   * mails.
+   *
+   * On resynchronise donc l'état via l'API publique `show-list` du cœur, juste
+   * après que celui-ci ait fini de traiter l'événement `load` de l'iframe.
+   */
+  $(document).ready(() => {
+    if (rcmail.env.task !== 'mail') return;
+    const content_frame = document.getElementById(rcmail.env.contentframe);
+
+    if (!content_frame) {
+      return;
+    }
+
+    $(content_frame).on('load', async (e) => {
+      const helper = await module_helper_mel.load_mel_object();
+      if (!helper.Empty().isLayoutSmallOfPhone()) return;
+
+      let win;
+
+      try {
+        win = e.target.contentWindow;
+      } catch (error) {
+        return;
+      }
+
+      const is_blank = win && win.location.href.endsWith(rcmail.env.blankpage);
+
+      if (!is_blank) {
+        return;
+      }
+
+      rcmail.triggerEvent('show-list', { force: true });
+    });
+  });
+}


### PR DESCRIPTION
>Sur smartphone, dans la navigation des mails :
> En ouvrant un message, le click sur la flèche retour (<) en haut à gauche ne fonctionne pas bien.

Lié à https://github.com/messagerie-melanie2/Roundcube-Mel/pull/65

