### PR TITLE
0009316- :bug: zone PJ absente ou tronquée en réponse

### DIFF
--- a/skins/mel_elastic/styles/less/mails.less
+++ b/skins/mel_elastic/styles/less/mails.less
@@ -78,6 +78,12 @@
         }
       }
     }
+
+    // BNUM - 0009316 : zone PJ absente/tronquée en réponse 
+    // min-width: auto  empêche #layout-content  de se compresser, ce qui posser la colonne PJ hors du viewport
+    #layout-content {
+      min-width: 0; 
+    }
   }
 
   &.action-preview {

--- a/skins/mel_elastic/styles/mails.css
+++ b/skins/mel_elastic/styles/mails.css
@@ -57,6 +57,9 @@ html.layout-large .task-mail #layout-sidebar > .header {
 .task-mail.action-compose #layout #layout-content > .header span {
   color: var(--layout-content-header-text-color);
 }
+.task-mail.action-compose #layout-content {
+  min-width: 0;
+}
 .task-mail.action-preview .ui.alert.boxinformation {
   color: var(--box-information-text-color);
   background-color: var(--box-information-background-color);


### PR DESCRIPTION
Le formulaire de rédaction (#layout-content) avait un min-width: auto qui l'empêchait de se compresser et poussait la colonne pièces jointes hors de l'écran. il me faut min-width à 0 sur #layout-content dans &.action-compose