### PR TITLE
0009140 - 🐛 Suppression d'une occurrence et les suivantes par le participant : "Rendre actif le bouton de la modale de suppression"

### DIFF
--- a/plugins/calendar/calendar_ui.js
+++ b/plugins/calendar/calendar_ui.js
@@ -3804,19 +3804,15 @@ function rcube_calendar_ui(settings) {
       }
     }
 
-    // recurring event: user needs to select the savemode
+        // recurring event: user needs to select the savemode
     if (event.recurrence) {
-      var future_disabled = '',
-        message_label =
-          action == 'remove'
-            ? 'removerecurringeventwarning'
-            : 'changerecurringeventwarning';
+      var message_label =
+        action == 'remove'
+          ? 'removerecurringeventwarning'
+          : 'changerecurringeventwarning';
 
-      // disable the 'future' savemode if I'm an attendee
-      // reason: no calendaring system supports the thisandfuture range parameter in iTip REPLY
-      if (action == 'remove' && !_is_organizer && _is_attendee) {
-        future_disabled = ' disabled';
-      }
+      // MANTIS 0009140: masquer le mode "future" lorsque je suis simple participant.
+      var future_hidden = action == 'remove' && !_is_organizer && _is_attendee;
 
       html +=
         '<div class="message dialog-message ui alert boxwarning">' +
@@ -3826,11 +3822,11 @@ function rcube_calendar_ui(settings) {
         '<a href="#current" class="button btn btn-secondary">' +
         rcmail.gettext('currentevent', 'calendar') +
         '</a>' +
-        '<a href="#future" class="button btn btn-secondary' +
-        future_disabled +
-        '">' +
-        rcmail.gettext('futurevents', 'calendar') +
-        '</a>' +
+        (future_hidden
+          ? ''
+          : '<a href="#future" class="button btn btn-secondary">' +
+            rcmail.gettext('futurevents', 'calendar') +
+            '</a>') +
         '<a href="#all" class="button btn btn-secondary">' +
         rcmail.gettext('allevents', 'calendar') +
         '</a>' +
@@ -3868,6 +3864,8 @@ function rcube_calendar_ui(settings) {
               data._decline = $dialog.find(
                 'input.confirm-attendees-decline:checked',
               ).length;
+              //Mantis 0009140 pasz de reply possible sur un rang THISANDFUTURE
+              data._decline = data.find('input.confirm-attendees-decline:checked').length;
               data._notify = 0;
             }
             update_event(action, data);


### PR DESCRIPTION
Dans update_event_confirm() (calendar_ui.js), la condition qui ajoutait la classe disabled au bouton « Cette occurrence et toutes les suivantes » a été remplacée par une variable future_hidden qui n'émet plus du tout le lien #future quand l'utilisateur est simple participant sur une suppression.

Avant:
<img width="467" height="357" alt="occuren1" src="https://github.com/user-attachments/assets/9c833391-ea6a-4662-885b-9cb38997feba" />

Après:
<img width="563" height="322" alt="image" src="https://github.com/user-attachments/assets/728aba07-dde0-4405-88b2-b26c3f03fd28" />
le participant souhaite garder juste les occurrences passées
<img width="567" height="330" alt="image" src="https://github.com/user-attachments/assets/1d29bfb0-601c-46f2-b0fe-fb52f8fa5c86" />
