### PR TITLE
:ambulance: Corrections de failles de sécurités

### DIFF
--- a/plugins/calendar/calendar.php
+++ b/plugins/calendar/calendar.php
@@ -241,6 +241,59 @@ class calendar extends rcube_plugin
     }
 
     /**
+     * PAMELLA
+     * 
+     * Récupère les différents chemins relatifs aux drivers du calendrier
+     * @param $driver_name Nom du dossier
+     * @param $driver_class Nom du fichier php et de sa classe
+     */
+    private function _getDrivers(string $driver_name, string $driver_class): array {
+        $BASE = $this->home . '/drivers';
+        return ['base' => $BASE, 
+                'calendar' => "$BASE/calendar_driver.php", 
+                'config' => "$BASE/$driver_name/$driver_class.php"];
+    }
+
+    private function _trySafeRequireDrivers(array $drivers): void {
+        if (!class_exists('mel_helper')) {
+            $loaded = include_once __DIR__."/../mel_helper/mel_helper.php";
+
+            if (!$loaded) {
+                $MESSAGE = '/!\\ Impossible de charger "mel_helper" !';
+                try {
+                    mel_logs::gi()->log(mel_logs::WARN, $MESSAGE);
+                } catch (\Throwable $th) {
+                    rcmail::get_instance()->write_log('warnings', $MESSAGE);
+                }
+                
+                if (rcmail::get_instance()->config->get('allow_unsafe_require', false) === true) {
+                    $this->_requireDriver($drivers);  
+                    return;
+                }
+                else {
+                    header('HTTP/1.0 404 Not Found');
+                    exit;
+                }
+            }   
+        }   
+
+        $this->_safeRequireDrivers($drivers);
+    }
+
+    private function _safeRequireDrivers(array $drivers): void {
+        $baseDir = $drivers['base'];
+        $calendarDriver = $drivers['calendar'];
+        $configDriver = $drivers['config'];
+        mel_helper::safe_require($baseDir, $calendarDriver);
+        mel_helper::safe_require($baseDir, $configDriver);
+    }
+
+    private function _requireDriver(array $drivers) {
+        require_once($drivers['calendar']);
+        require_once($drivers['config']);   
+    }
+
+    /**
      * Helper method to load the backend driver according to local config
      */
     private function load_driver()
@@ -252,8 +305,8 @@ class calendar extends rcube_plugin
         $driver_name = $this->rc->config->get('calendar_driver', 'database');
         $driver_class = $driver_name . '_driver';
 
-        require_once($this->home . '/drivers/calendar_driver.php');
-        require_once($this->home . '/drivers/' . $driver_name . '/' . $driver_class . '.php');
+        //PAMELA - Avoid injection
+        $this->_trySafeRequireDrivers($this->_getDrivers($driver_name, $driver_class));
 
         $this->driver = new $driver_class($this);
 

--- a/plugins/calendar/calendar.php
+++ b/plugins/calendar/calendar.php
@@ -243,17 +243,37 @@ class calendar extends rcube_plugin
     /**
      * PAMELLA
      * 
-     * Récupère les différents chemins relatifs aux drivers du calendrier
-     * @param $driver_name Nom du dossier
-     * @param $driver_class Nom du fichier php et de sa classe
+     * Récupère les chemins relatifs aux fichiers driver du calendrier (driver
+     * générique + driver de configuration spécifique).
+     *
+     * @param string $driver_name  Nom du dossier du driver (ex. "database")
+     * @param string $driver_class Nom du fichier PHP et de la classe du driver de configuration
+     *
+     * @return array<string, string> Chemins associés : 'base' (dossier), 'calendar'
+     *                                (fichier driver générique), 'config' (fichier driver spécifique)
      */
     private function _getDrivers(string $driver_name, string $driver_class): array {
         $BASE = $this->home . '/drivers';
-        return ['base' => $BASE, 
-                'calendar' => "$BASE/calendar_driver.php", 
-                'config' => "$BASE/$driver_name/$driver_class.php"];
+        return ['base' => $BASE,
+                'calendar' => 'calendar_driver.php',
+                'config' => "$driver_name/$driver_class.php"];
     }
 
+    /**
+     * PAMELLA
+     * 
+     * Tente de charger les drivers de façon sécurisée via mel_helper::safe_require().
+     *
+     * Si mel_helper n'est pas disponible, un chargement non sécurisé n'est autorisé
+     * que si la config `allow_unsafe_require` est explicitement activée ; sinon la
+     * requête est bloquée (404). $driver_name/$driver_class proviennent de la config
+     * utilisateur, d'où la nécessité de valider les chemins avant inclusion (protection
+     * contre l'injection de chemin).
+     *
+     * @param array<string, string> $drivers Chemins des drivers (voir {@link _getDrivers})
+     *
+     * @return void
+     */
     private function _trySafeRequireDrivers(array $drivers): void {
         if (!class_exists('mel_helper')) {
             $loaded = include_once __DIR__."/../mel_helper/mel_helper.php";
@@ -280,6 +300,15 @@ class calendar extends rcube_plugin
         $this->_safeRequireDrivers($drivers);
     }
 
+    /**
+     * PAMELLA
+     * 
+     * Inclut les fichiers driver en validant les chemins via mel_helper::safe_require().
+     *
+     * @param array<string, string> $drivers Chemins des drivers (voir {@link _getDrivers})
+     *
+     * @return void
+     */
     private function _safeRequireDrivers(array $drivers): void {
         $baseDir = $drivers['base'];
         $calendarDriver = $drivers['calendar'];
@@ -288,9 +317,21 @@ class calendar extends rcube_plugin
         mel_helper::safe_require($baseDir, $configDriver);
     }
 
-    private function _requireDriver(array $drivers) {
-        require_once($drivers['calendar']);
-        require_once($drivers['config']);   
+    /**
+     * PAMELLA
+     * 
+     * Inclut les fichiers driver sans validation des chemins.
+     *
+     * Utilisé uniquement en repli lorsque mel_helper est indisponible et que la
+     * config `allow_unsafe_require` autorise explicitement ce mode non sécurisé.
+     *
+     * @param array<string, string> $drivers Chemins des drivers (voir {@link _getDrivers})
+     *
+     * @return void
+     */
+    private function _requireDriver(array $drivers): void {
+        require_once($drivers['base'] . '/' . $drivers['calendar']);
+        require_once($drivers['base'] . '/' . $drivers['config']);
     }
 
     /**

--- a/plugins/calendar/config.inc.php.dist
+++ b/plugins/calendar/config.inc.php.dist
@@ -150,5 +150,5 @@ $config['kolab_invitation_calendars'] = false;
 // Set it to the prefix URL, e.g. 'https://hostname/freebusy' or just '/freebusy'.
 // See freebusy_session_auth in configuration of kolab_auth plugin.
 $config['calendar_freebusy_session_auth_url'] = null;
-
+$config['allow_unsafe_require'] = false;
 ?>

--- a/plugins/mel/lib/drivers/driver_mel.php
+++ b/plugins/mel/lib/drivers/driver_mel.php
@@ -87,8 +87,13 @@ abstract class driver_mel {
    */
   public static function get_instance() {
     if (!isset(self::$driver)) {
+      if (!class_exists('mel_helper')) include_once __DIR__."/../../../mel_helper/mel_helper.php";
+
       $drivername = strtolower(rcmail::get_instance()->config->get('mel_driver', 'mce'));
-      require_once $drivername . '/' . $drivername . '.php';
+      //require_once $drivername . '/' . $drivername . '.php';
+
+      mel_helper::safe_require(__DIR__, $drivername . '/' . $drivername . '.php');
+
       $drivername = $drivername . '_driver_mel';
       self::$driver = new $drivername();
     }

--- a/plugins/mel_doubleauth/mel_doubleauth.php
+++ b/plugins/mel_doubleauth/mel_doubleauth.php
@@ -126,7 +126,7 @@ class mel_doubleauth extends bnum_plugin
 
         if (isset($_COOKIE['roundcube_login'])) {
             // Vérifier la présence du cookies
-            if (isset($_COOKIE['roundcube_doubleauth'])) {
+            if (false && isset($_COOKIE['roundcube_doubleauth'])) {
                 $info_doubleauth = explode('###', $_COOKIE['roundcube_doubleauth']);
                 if (count($info_doubleauth) == 4) {
                     // test d'expiration cookies

--- a/plugins/mel_doubleauth/mel_doubleauth.php
+++ b/plugins/mel_doubleauth/mel_doubleauth.php
@@ -54,6 +54,13 @@ class mel_doubleauth extends bnum_plugin
         if (!$this->is_internal()) { // Connexion intranet => pas de double auth
             $this->add_hook('login_after', [$this,'login_after']);
             $this->add_hook('logout_after', array($this, 'logout_after'));
+            // __exitSession() détruit désormais la session côté serveur avant la redirection
+            // (cf. sa docblock) : au moment où le client suit cette redirection vers
+            // ?_task=logout, $_SESSION['user_id'] n'existe plus, donc le cœur de Roundcube
+            // ne déclenche pas 'logout_after' et affiche directement la page de connexion via
+            // le hook 'unauthenticated'. Sans ce hook supplémentaire, le message
+            // (_logout_msg, toujours présent dans l'URL) ne serait jamais affiché.
+            $this->add_hook('unauthenticated', array($this, 'logout_after'));
             $this->add_hook('send_page', array($this, 'check_2FAlogin'));
             $this->add_hook('render_page', array($this, 'popup_msg_enrollment'));
             $this->add_hook('once_per_day', [$this,'hook_oncePerDay']);

--- a/plugins/mel_doubleauth/mel_doubleauth.php
+++ b/plugins/mel_doubleauth/mel_doubleauth.php
@@ -61,6 +61,8 @@ class mel_doubleauth extends bnum_plugin
             // Si on est internal on considère qu'on s'est connecté avec la double auth (en cas de changement de VPN)
             $_SESSION['mel_doubleauth_login'] = time();
             $_SESSION['mel_doubleauth_2FA_login'] = time();
+            // La double authentification est court-circuitée, on trace quand même l'orientation
+            $this->add_hook('login_after', [$this, 'log_login_destination_internal']);
         }
 
         $this->add_texts('localization/', true);
@@ -112,7 +114,10 @@ class mel_doubleauth extends bnum_plugin
     public function login_after($args)
     {
         //mel_logs::get_instance()->log(mel_logs::DEBUG, "doubleauth_login_after");
-        if ($this->is_auth_strong()) return $args;
+        if ($this->is_auth_strong()) {
+            $this->__logLoginDestination('bnum', self::date_grace_enabled() ? 'delai_de_grace' : 'auth_forte');
+            return $args;
+        }
 
         $_SESSION['mel_doubleauth_login'] = time();
 
@@ -140,6 +145,8 @@ class mel_doubleauth extends bnum_plugin
                             // envoi des données au webservice pour sauvegarde en base
                             $this->__modifyCookie($info_doubleauth[0], $info_doubleauth[1], intval($expiration), "roundcube");
 
+                            $this->__logLoginDestination('bnum', 'cookie_2fa_valide');
+
                             if (isset($url) && $url !== '') $this->__goingToUrl($url);
                             else $this->__goingRoundcubeTask($this->rc->config->get('default_task', 'mail'));
                         } else {
@@ -166,10 +173,14 @@ class mel_doubleauth extends bnum_plugin
 
         if (!$config_2FA['activate']) {
             if ($this->rc->config->get('force_enrollment_users')) {
+                $this->__logLoginDestination('enrolement_2fa', 'enrolement_force');
                 $this->__goingRoundcubeTask('settings', 'plugin.mel_doubleauth');
             }
+            $this->__logLoginDestination('bnum', '2fa_inactive');
             return $args;
         }
+
+        $this->__logLoginDestination('page_2fa', '2fa_active');
 
         $this->rc->output->set_pagetitle($this->gettext('mel_doubleauth'));
 
@@ -182,6 +193,40 @@ class mel_doubleauth extends bnum_plugin
         $this->rc->output->set_env("_url", $url);
 
         $this->rc->output->send('login');
+    }
+
+    /**
+     * Hook login_after déclenché uniquement sur les connexions intranet
+     * La double authentification y est court-circuitée : il n'y a rien à faire,
+     * on trace juste l'orientation de l'utilisateur
+     *
+     * @param array $args
+     */
+    public function log_login_destination_internal($args)
+    {
+        $this->__logLoginDestination('bnum', 'intranet');
+
+        return $args;
+    }
+
+    /**
+     * Trace où l'utilisateur est envoyé juste après une connexion réussie
+     *
+     * Cette information n'est pas observable depuis mel_logs : elle est décidée ici,
+     * et chaque branche se termine par un exit (redirection ou envoi de la page).
+     * Complète les lignes de mel_logs sans les modifier.
+     *
+     * @param string $destination bnum|page_2fa|enrolement_2fa|deconnexion
+     * @param string $motif raison de cette orientation
+     */
+    private function __logLoginDestination($destination, $motif)
+    {
+        $url = rcube_utils::get_input_value('_url', rcube_utils::INPUT_GPC);
+
+        mel_logs::get_instance()->log(mel_logs::INFO,
+            "[login] Orientation après connexion <" . $this->rc->get_user_name() . ">"
+                . " | destination=" . $destination
+                . " | motif=" . $motif);
     }
 
     private function login_after_check_deadline($config_2FA, $user = null)
@@ -200,10 +245,12 @@ class mel_doubleauth extends bnum_plugin
                 !$config_2FA['activate'] &&
                 (!$deadline || new DateTime() > $deadline)
             ) {
+                $this->__logLoginDestination('deconnexion', '2fa_obligatoire_hors_delai');
                 $this->__exitSession($this->gettext('logout_2fa_needed_not_secure'));
                 $return = false;
             }
         } else {
+            $this->__logLoginDestination('deconnexion', 'utilisateur_inconnu');
             $this->__exitSession($this->gettext('logout_2fa_needed_unknown'));
             $return = false;
         }

--- a/plugins/mel_doubleauth/mel_doubleauth.php
+++ b/plugins/mel_doubleauth/mel_doubleauth.php
@@ -37,6 +37,8 @@ class mel_doubleauth extends bnum_plugin
      */
     const EXPIRE_COOKIE = 2592000;
 
+    const COOKIE_MEMORY_ENABLED = false;
+
     /**
      * Initialisation du plugin
      *
@@ -111,6 +113,10 @@ class mel_doubleauth extends bnum_plugin
         }
     }
 
+    private function _cookieDoubleAuthEnabled() {
+        return self::COOKIE_MEMORY_ENABLED;
+    }
+
     /**
      * Hook login_after
      * Permet d'afficher la demande de double authentification en js
@@ -138,7 +144,7 @@ class mel_doubleauth extends bnum_plugin
 
         if (isset($_COOKIE['roundcube_login'])) {
             // Vérifier la présence du cookies
-            if (false && isset($_COOKIE['roundcube_doubleauth'])) {
+            if ($this->_cookieDoubleAuthEnabled() && isset($_COOKIE['roundcube_doubleauth'])) {
                 $info_doubleauth = explode('###', $_COOKIE['roundcube_doubleauth']);
                 if (count($info_doubleauth) == 4) {
                     // test d'expiration cookies

--- a/plugins/mel_doubleauth/mel_doubleauth.php
+++ b/plugins/mel_doubleauth/mel_doubleauth.php
@@ -849,22 +849,74 @@ class mel_doubleauth extends bnum_plugin
 
     /**
      * Destruction de la session de l'utilisateur (via Logout)
-     * 
+     *
+     * ATTENTION : la redirection émise en fin de méthode n'est qu'une instruction
+     * donnée au client, qui reste libre de l'ignorer. Toute la destruction doit
+     * donc être faite ici, côté serveur, AVANT le exit : sans quoi un client qui
+     * ne suit pas la redirection conserve une session pleinement authentifiée.
+     *
      * @param string $message
+     * @param bool $da_logout_message
      */
     private function __exitSession($message = null, $da_logout_message = true)
     {
-        unset($_SESSION['mel_doubleauth_login']);
-        unset($_SESSION['mel_doubleauth_2FA_login']);
+        // Tracé ici explicitement : le hook session_destroy de mel_logs s'inhibe
+        // sur la tâche login, or __exitSession() est appelé depuis login_after.
+        // Sans cette ligne la destruction resterait invisible dans les logs.
+        mel_logs::get_instance()->log(mel_logs::INFO,
+            "[logout] Destruction de session (rejet 2FA) <" . $this->rc->get_user_name() . ">");
+
+        $this->__destroySession();
+
+        $params = ['_task' => 'logout'];
 
         if (isset($message)) {
-            header('Location: ?_task=logout&_logout_msg=' . $message . '&_da_logout_message='.$da_logout_message.'&_token=' . $this->rc->get_request_token());
-        } else {
-            header('Location: ?_task=logout&_token=' . $this->rc->get_request_token());
+            $params['_logout_msg'] = $message;
+            $params['_da_logout_message'] = $da_logout_message ? 1 : 0;
         }
 
+        // Le jeton de requête n'est volontairement plus transmis : il est lu dans
+        // $_SESSION, qui n'existe plus. La tâche logout sur une session anonyme
+        // renvoie de toute façon vers la page de connexion.
 
+        // Une requête AJAX ne fait rien d'exploitable d'une redirection HTTP nue :
+        // le client JS de Roundcube attend une commande, on la lui envoie.
+        if (is_object($this->rc->output) && $this->rc->output->type == 'js') {
+            $this->rc->output->redirect($params);
+            exit;
+        }
+
+        header('Location: ?' . http_build_query($params));
         exit;
+    }
+
+    /**
+     * Destruction effective et immédiate de la session, côté serveur
+     *
+     * kill_session() ne suffit pas à lui seul avec session_storage = php :
+     * rcube_session_php::destroy() est une méthode vide, et l'effacement réel
+     * reposerait alors sur la seule réécriture de $_SESSION en fin de requête.
+     * Le pilote php n'appelant jamais register_session_handler(), c'est le
+     * gestionnaire natif de PHP qui est actif : session_destroy() supprime donc
+     * bien l'enregistrement.
+     */
+    private function __destroySession()
+    {
+        // Vide $_SESSION, réinitialise l'utilisateur, supprime le cookie
+        // d'authentification de session et déclenche le hook session_destroy.
+        $this->rc->kill_session();
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            // Supprime l'enregistrement portant l'identifiant que le client
+            // détient : cet identifiant ne doit plus rien désigner. La session
+            // n'étant plus active, le write_close() de fin de requête devient un
+            // no-op et plus rien n'est écrit.
+            $_SESSION = [];
+            session_destroy();
+        }
+
+        // Et le cookie de session lui-même
+        rcube_utils::setcookie(session_name(), '', time() - 3600);
     }
 
     /**

--- a/plugins/mel_helper/mel_helper.php
+++ b/plugins/mel_helper/mel_helper.php
@@ -195,6 +195,25 @@ class mel_helper extends rcube_plugin
        return $html;
     }
 
+    /**
+ * Charge un fichier PHP en vérifiant qu'il reste dans le dossier autorisé.
+ * Remplace les require_once avec chemin dynamique.
+ */
+    public static function safe_require(string $base_dir, string $relative_path): string
+    {
+        $base     = realpath($base_dir);
+        $resolved = realpath($base_dir . '/' . $relative_path);
+
+        if ($resolved === false || strpos($resolved, $base . DIRECTORY_SEPARATOR) !== 0) {
+            mel_logs::gi()->log(mel_logs::ERROR, "safe_require: chemin non autorisé '$relative_path'");
+            rcube::raise_error("safe_require: chemin non autorisé '$relative_path'", true, true);
+            throw new RuntimeException("Chemin de driver non autorisé");
+        }
+
+        require_once $resolved;
+        return $resolved;
+    }
+
     public static function settings($only_include = false)
     {
         include_once "lib/mel_settings.php";

--- a/plugins/mel_labels_sync/lib/driver.php
+++ b/plugins/mel_labels_sync/lib/driver.php
@@ -115,7 +115,11 @@ class Driver {
     }
     else {
       // Récupère la liste des étiquettes
-      $value = driver_mel::gi()->getUser($username)->getPreference(self::PREF_SCOPE, self::PREF_NAME);
+      try {
+              $value = driver_mel::gi()->getUser($username)->getPreference(self::PREF_SCOPE, self::PREF_NAME);
+      } catch (\Throwable $th) {
+        return [];
+      }
       $labels = isset($value) ? $this->_m2_to_rc($value, $username) : [];
 
       if (!$this->_add_defaults_labels($username, $labels)) {

--- a/plugins/mel_logs/mel_logs.php
+++ b/plugins/mel_logs/mel_logs.php
@@ -43,6 +43,14 @@ class mel_logs extends rcube_plugin
 	 */
 	private static $instance;
 
+	/**
+	 * Photographie de la session prise juste avant sa destruction
+	 * kill_session() vide $_SESSION avant l'appel du hook logout_after,
+	 * les informations de la session ne sont donc plus lisibles à ce moment là
+	 * @var array
+	 */
+	private static $session_context = [];
+
     /**
      * @var string
      */
@@ -85,6 +93,8 @@ class mel_logs extends rcube_plugin
 		$this->add_hook('login_after', array($this, 'login_after'));
 		$this->add_hook('login_failed', array($this, 'login_failed'));
 		$this->add_hook('message_sent', array($this, 'message_sent'));
+		$this->add_hook('session_destroy', array($this, 'session_destroy'));
+		$this->add_hook('logout_after', array($this, 'logout_after'));
 
 		$this->logOnInit();
 	}
@@ -154,7 +164,40 @@ class mel_logs extends rcube_plugin
 			$this->log(self::INFO, "[login] Connexion directe BALP <".rcmail::get_instance()->get_user_name()."> [" . driver_mel::gi()->getUser()->type . "]");
 		}
 
+		// Détail du contexte de connexion (réseau, niveau d'authentification, client, ...)
+		$this->log_login_details();
+
 	    return $args;
+	}
+
+	/**
+	 * Trace détaillée du contexte de la connexion
+	 * Complète la ligne "[login] Connexion réussie" sans la modifier
+	 */
+	private function log_login_details()
+	{
+		$rc = rcmail::get_instance();
+
+		$eidas = isset($_SESSION['eidas']) ? $_SESSION['eidas'] : '';
+		$interne = $this->_is_internal();
+		$auth_forte = $interne || in_array($eidas, ['eidas2', 'eidas3']);
+
+		$details = [
+			'reseau'      => $interne ? 'intranet' : 'internet',
+			'auth'        => isset($_SESSION['auth_type']) ? $_SESSION['auth_type'] : 'password',
+			'eidas'       => $eidas !== '' ? $eidas : 'aucun',
+			'auth_forte'  => $auth_forte ? 'oui' : 'non',
+			'2fa'         => $this->_login_2fa_state($auth_forte),
+			'cookie_2fa'  => isset($_COOKIE['roundcube_doubleauth']) ? 'oui' : 'non',
+		];
+
+		$message = "[login] Détail connexion <".$rc->get_user_name().">";
+		foreach ($details as $key => $value) {
+			$message .= " | $key=$value";
+		}
+		$message .= ' | ua="'.(isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '-').'"';
+
+		$this->log(self::INFO, $message);
 	}
 	/**
 	 * Login failed
@@ -169,6 +212,94 @@ class mel_logs extends rcube_plugin
 		$this->log(self::INFO, "[login] Echec de connexion pour l'utilisateur <".$args['user']."> Code erreur : ".$args['code'].$message);
 		return $args;
 	}
+	/**
+	 * Hook session_destroy
+	 * Appelé par kill_session() alors que la session est encore lisible
+	 * On en profite pour photographier la session, et pour tracer les fins de
+	 * session qui ne passeront pas par le hook logout_after (session expirée,
+	 * ré-authentification forcée par un plugin, ...)
+	 */
+	public function session_destroy($args)
+	{
+		$rc = rcmail::get_instance();
+
+		// Purge de session sur la page de login (nouvelle authentification) : aucune
+		// session utilisateur ne se termine ici, il ne faut ni photographier ni tracer
+		// sous peine de polluer les lignes de log de la connexion qui suit
+		if (empty($_SESSION['user_id']) || $rc->task === 'login') {
+			return $args;
+		}
+
+		self::$session_context = [
+			'user'       => $rc->get_user_name() ?: (isset($_SESSION['username']) ? $_SESSION['username'] : ''),
+			'login_time' => isset($_SESSION['login_time']) ? $_SESSION['login_time'] : null,
+			'host'       => isset($_SESSION['storage_host']) ? $_SESSION['storage_host'] : '-',
+			'eidas'      => isset($_SESSION['eidas']) ? $_SESSION['eidas'] : '',
+			'auth_type'  => isset($_SESSION['auth_type']) ? $_SESSION['auth_type'] : 'password',
+			'doubleauth' => isset($_SESSION['mel_doubleauth_2FA_login']),
+			'session'    => $this->_short_session_id(),
+		];
+
+		// Sur la tâche logout le hook logout_after prend le relais juste après,
+		// ailleurs c'est une fin de session subie (expiration, ré-authentification
+		// forcée par un plugin, ...) qui ne sera tracée que d'ici
+		if ($rc->task !== 'logout') {
+			$this->log(self::INFO, $this->_logout_message($rc->task, $rc->action));
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Hook logout_after
+	 * Déconnexion explicite demandée par l'utilisateur
+	 */
+	public function logout_after($args)
+	{
+		if (!empty($args['user'])) {
+			self::$session_context['user'] = $args['user'];
+		}
+		if (!empty($args['host'])) {
+			self::$session_context['host'] = $args['host'];
+		}
+
+		$this->log(self::INFO, $this->_logout_message('explicite'));
+
+		return $args;
+	}
+
+	/**
+	 * Construit la ligne de log de déconnexion à partir de la photographie de session
+	 *
+	 * @param string $task tâche en cours (fin de session uniquement)
+	 * @param string $action action en cours (fin de session uniquement)
+	 *
+	 * @return string
+	 */
+	private function _logout_message($task = null, $action = null)
+	{
+		$ctx = self::$session_context;
+
+		$user = isset($ctx['user']) ? $ctx['user'] : '';
+		$login_time = isset($ctx['login_time']) ? $ctx['login_time'] : null;
+
+		$details = [
+			'duree'  => $login_time ? $this->_format_duration(time() - intval($login_time)) : 'inconnue',
+			'reseau' => $this->_is_internal() ? 'intranet' : 'internet',
+			'auth'   => isset($ctx['auth_type']) ? $ctx['auth_type'] : 'password',
+			'eidas'  => !empty($ctx['eidas']) ? $ctx['eidas'] : 'aucun',
+			'2fa'    => !empty($ctx['doubleauth']) ? 'validee' : 'non',
+			'host'   => isset($ctx['host']) ? $ctx['host'] : '-',
+		];
+
+		$message = "[logout] Déconnexion de l'utilisateur <$user>";
+		foreach ($details as $key => $value) {
+			$message .= " | $key=$value";
+		}
+
+		return $message;
+	}
+
 	/**
 	 * Triggered when a message is finally sent
 	 * This hook doesn't have any return values but can be used for logging or notifications.
@@ -199,7 +330,7 @@ class mel_logs extends rcube_plugin
 
 		// Fichier de log spécifique
 		$rcmail = rcmail::get_instance();
-		$username = $rcmail->get_user_name();
+		$username = $this->_current_username();
 		if (in_array($level, [self::TRACE, self::DEBUG, self::ERROR, self::INFO])
 				&& in_array($username, $rcmail->config->get('mel_logs_trace_users', []))) {
 			$this->write_log($username, $level, $message);
@@ -221,10 +352,10 @@ class mel_logs extends rcube_plugin
 	{
 		$ip = $this->_get_address_ip();
 		$procid = getmypid();
-		$username = rcmail::get_instance()->get_user_name();
+		$username = $this->_current_username();
 		$provenance = rcmail::get_instance()->config->get('provenance');
 		$courrielleur = isset($_GET['_courrielleur']) ? " {Courrielleur}" : " {Web}";
-		$doubleauth = isset($_SESSION['mel_doubleauth_2FA_login']) ? " [doubleauth]" : "";
+		$doubleauth = $this->_is_doubleauth() ? " [doubleauth]" : "";
 		rcmail::get_instance()->write_log($log_file, "[$level] $ip ($provenance)$doubleauth PROC[$procid]$courrielleur $username - $message");
 	}
 
@@ -242,6 +373,109 @@ class mel_logs extends rcube_plugin
 	}
 
 	/******** PRIVATE **********/
+	/**
+	 * Retourne l'utilisateur courant
+	 * Après kill_session() l'utilisateur n'est plus connu de rcmail, on se rabat
+	 * alors sur la photographie prise dans le hook session_destroy
+	 * @return string
+	 * @private
+	 */
+	private function _current_username()
+	{
+		$username = rcmail::get_instance()->get_user_name();
+
+		if (empty($username) && !empty(self::$session_context['user'])) {
+			$username = self::$session_context['user'];
+		}
+
+		return $username;
+	}
+
+	/**
+	 * La session courante a-t-elle valide la double authentification ?
+	 * Après kill_session() l'information n'est plus dans $_SESSION, on se rabat
+	 * sur la photographie prise dans le hook session_destroy
+	 * @return boolean
+	 * @private
+	 */
+	private function _is_doubleauth()
+	{
+		if (isset($_SESSION['mel_doubleauth_2FA_login'])) {
+			return true;
+		}
+
+		return empty(rcmail::get_instance()->get_user_name()) && !empty(self::$session_context['doubleauth']);
+	}
+
+	/**
+	 * Connexion depuis le réseau interne ?
+	 * Copie locale du test de mel::is_internal() : mel_logs est chargé très tôt
+	 * et ne doit pas dépendre du plugin mel
+	 * @return boolean
+	 * @private
+	 */
+	private function _is_internal()
+	{
+		if (isset($_GET['internet'])) {
+			return false;
+		}
+
+		return (bool) rcmail::get_instance()->config->get('is_internal', false);
+	}
+
+	/**
+	 * État de la double authentification au moment de la connexion
+	 * @param boolean $auth_forte
+	 * @return string
+	 * @private
+	 */
+	private function _login_2fa_state($auth_forte)
+	{
+		if (isset($_SESSION['mel_doubleauth_2FA_login'])) {
+			return 'validee';
+		}
+
+		return $auth_forte ? 'non_requise' : 'en_attente';
+	}
+
+	/**
+	 * Identifiant court de session, permet de corréler les lignes de log
+	 * @return string
+	 * @private
+	 */
+	private function _short_session_id()
+	{
+		$id = session_id();
+
+		return empty($id) ? '-' : substr($id, 0, 8);
+	}
+
+	/**
+	 * Formatte une durée en secondes
+	 * @param int $seconds
+	 * @return string
+	 * @private
+	 */
+	private function _format_duration($seconds)
+	{
+		if ($seconds < 0) {
+			return 'inconnue';
+		}
+
+		$hours = intdiv($seconds, 3600);
+		$minutes = intdiv($seconds % 3600, 60);
+		$seconds = $seconds % 60;
+
+		if ($hours) {
+			return sprintf('%dh%02dm%02ds', $hours, $minutes, $seconds);
+		}
+		if ($minutes) {
+			return sprintf('%dm%02ds', $minutes, $seconds);
+		}
+
+		return $seconds . 's';
+	}
+
 	/**
 	 * Retourne l'adresse ip
 	 * @return string

--- a/plugins/mel_news/mel_news.php
+++ b/plugins/mel_news/mel_news.php
@@ -1,6 +1,8 @@
 <?php
 class mel_news extends rcube_plugin {
   private const RSS_ENABLED = false;
+  private const WRITE_ENABLED = false;
+  private const READ_ENABLED = false;
 
   /**
    *
@@ -155,7 +157,6 @@ class mel_news extends rcube_plugin {
 
   function check_user()
   {
-    $user;
     $val = rcube_utils::get_input_value("_uid", rcube_utils::INPUT_GPC);
     if (strpos($val, "@") !== false) $user = driver_mel::gi()->getUser(null, true, false, null, $val);
     else  $user = driver_mel::gi()->getUser($val);
@@ -916,6 +917,12 @@ class mel_news extends rcube_plugin {
 
   public function get_rss_data()
   {
+    if (!self::RSS_ENABLED)
+    {
+      header('HTTP/1.0 404 Not Found');
+      exit;
+    }
+
     $fileName = rcube_utils::get_input_value("_file", rcube_utils::INPUT_GPC);
     $url = rcube_utils::get_input_value("_url", rcube_utils::INPUT_GPC);
 
@@ -1040,6 +1047,8 @@ class mel_news extends rcube_plugin {
 
   private function write_to_file($fileName, $text)
   {
+    if (!self::WRITE_ENABLED) return;
+
     $folderPath = $this->rc->config->get('folder_path', 'files');
     $path = "$folderPath/$fileName";
 
@@ -1075,6 +1084,8 @@ class mel_news extends rcube_plugin {
 
   private function get_from_file($fileName, $check = true)
   {
+    if (!self::READ_ENABLED) return false;
+
     $folderPath = $this->rc->config->get('folder_path', 'files');
     $cacheTime = $this->rc->config->get('time_cache', 60) * 60;
 

--- a/plugins/tasklist/tasklist.php
+++ b/plugins/tasklist/tasklist.php
@@ -193,7 +193,9 @@ class tasklist extends rcube_plugin
         $driver_class = 'tasklist_' . $driver_name . '_driver';
 
         require_once($this->home . '/drivers/tasklist_driver.php');
-        require_once($this->home . '/drivers/' . $driver_name . '/' . $driver_class . '.php');
+        mel_helper::safe_require($this->home . '/drivers', $driver_name . '/' . $driver_class . '.php');
+        // require_once($this->home . '/drivers/' . $driver_name . '/' . $driver_class . '.php');
+        // mel_helper::safe_require()
 
         $this->driver = new $driver_class($this);
 

--- a/public/feed/index.php
+++ b/public/feed/index.php
@@ -73,7 +73,7 @@ if (isset($keyhash)) {
   $value = $user->getCalendarPreference("calendarskeyhash");
 
   if (isset($value)) {
-    $value = unserialize($value);
+    $value = unserialize($value, ['allowed_classes' => false]);
     if (!isset($value[$calendar_name]) || $value[$calendar_name] != $keyhash) {
       $keyhash = null;
     }

--- a/public/forgotten/includes/form.inc.php
+++ b/public/forgotten/includes/form.inc.php
@@ -25,7 +25,7 @@
                     <form action="." method="post">
                         <div class="form-group">
                             <div class="controls">
-                                <input type="email" name="_email" id="email" value="<?= (isset($user) ? $user->email : ""); ?>" class="floatLabel" required>
+                                <input type="email" name="_email" id="email" value="<?= htmlspecialchars(isset($user) ? $user->email : "", ENT_QUOTES); ?>" class="floatLabel" required>
                                 <label for="email">E-mail</label>
                             </div>
                             <div class="controls">

--- a/public/freebusy/index.php
+++ b/public/freebusy/index.php
@@ -70,9 +70,10 @@ if (!isset($end)) {
   $end = $start + (2 * $config['nb_days'] * 24 * 60 * 60);
 }
 if (isset($email)
-    && !isset($uid)) {
+    && !isset($uid)
+    && utils::check_email($email, false)) {
   // Récupération de l'utilisateur depuis le serveur LDAP
-  $infos = \LibMelanie\Ldap\Ldap::GetUserInfosFromEmail($email);
+  $infos = \LibMelanie\Ldap\Ldap::GetUserInfosFromEmail(utils::escape_ldap_filter($email));
   if (isset($infos)) {
     $uid = $infos['uid'][0];
   }

--- a/public/lib/extern/core.php
+++ b/public/lib/extern/core.php
@@ -63,9 +63,14 @@ class Core {
             $email = $params['email'];
             $key = $params['key'];
 
+            if (!utils::check_email($email, false)) {
+                utils::log("Extern/Core::Process() [$email] - Invalid email format");
+                return false;
+            }
+
             // Récupération de l'objet utilisateur
             $user = new LibMelanie\Api\Mel\User(\LibMelanie\Config\Ldap::$MASTER_LDAP, 'webmail.external.users');
-            $user->email = $email;
+            $user->email = utils::escape_ldap_filter($email);
 
             if (!$user->load(['uid', 'email', 'firstname', 'lastname'])) {
                 utils::log("Extern/Core::Process() [$email] - User not found");
@@ -203,9 +208,14 @@ class Core {
             // Récupération des paramètres de la requête
             $email = utils::get_input_value("_email", utils::INPUT_GPC);
 
+            if (!utils::check_email($email, false)) {
+                utils::log("Extern/Core::Reinit() [$email] - Invalid email format");
+                return false;
+            }
+
             // Récupération de l'objet utilisateur
             $user = new LibMelanie\Api\Mel\User();
-            $user->email = $email;
+            $user->email = utils::escape_ldap_filter($email);
 
             if (!$user->load(['uid', 'email'])) {
                 utils::log("Extern/Core::Reinit() [$email] - User not found");

--- a/public/lib/utils.php
+++ b/public/lib/utils.php
@@ -630,7 +630,7 @@ class utils
       $value = $user->getCalendarPreference("appointmentkeyhash");
 
       if (isset($value)) {
-        $value = unserialize($value);
+        $value = unserialize($value, ['allowed_classes' => false]);
         if (!isset($value[$calendar_name]) || $value[$calendar_name] != $keyhash) {
           $keyhash = null;
         }

--- a/public/lib/utils.php
+++ b/public/lib/utils.php
@@ -103,6 +103,17 @@ class utils
     return false;
   }
 
+  /**
+   * Échappe une valeur pour un usage sûr dans un filtre de recherche LDAP.
+   *
+   * @param string $value Valeur à échapper
+   *
+   * @return string Valeur échappée, utilisable dans un filtre LDAP
+   */
+  public static function escape_ldap_filter($value)
+  {
+    return ldap_escape($value, '', LDAP_ESCAPE_FILTER);
+  }
 
   /**
    * Validates IPv4 or IPv6 address

--- a/public/reinit/includes/form.inc.php
+++ b/public/reinit/includes/form.inc.php
@@ -8,10 +8,10 @@
 
             <div class="form-group">
                 <div class="controls">
-                    <input type="email" name="_email" id="email" value="<?= $user->email; ?>" readonly>
-                    <input type="hidden" name="_h" id="hash" value="<?= $hash; ?>">
-                    <input type="hidden" name="_firstname" id="firstname" value="<?= $user->firstname; ?>">
-                    <input type="hidden" name="_lastname" id="lastname" value="<?= $user->lastname; ?>">
+                    <input type="email" name="_email" id="email" value="<?= htmlspecialchars($user->email, ENT_QUOTES); ?>" readonly>
+                    <input type="hidden" name="_h" id="hash" value="<?= htmlspecialchars($hash, ENT_QUOTES); ?>">
+                    <input type="hidden" name="_firstname" id="firstname" value="<?= htmlspecialchars($user->firstname, ENT_QUOTES); ?>">
+                    <input type="hidden" name="_lastname" id="lastname" value="<?= htmlspecialchars($user->lastname, ENT_QUOTES); ?>">
                     <label for="email" class="active">E-mail</label>
                 </div>
                 <div class="controls">

--- a/public/welcome/includes/form.inc.php
+++ b/public/welcome/includes/form.inc.php
@@ -8,16 +8,16 @@
 
             <div class="form-group">
                 <div class="controls">
-                    <input type="email" name="_email" id="email" value="<?= $user->email; ?>" readonly>
-                    <input type="hidden" name="_h" id="hash" value="<?= $hash; ?>">
+                    <input type="email" name="_email" id="email" value="<?= htmlspecialchars($user->email, ENT_QUOTES); ?>" readonly>
+                    <input type="hidden" name="_h" id="hash" value="<?= htmlspecialchars($hash, ENT_QUOTES); ?>">
                     <label for="email" class="active">E-mail</label>
                 </div>
                 <div class="controls">
-                    <input type="text" name="_firstname" id="firstname" class="floatLabel" value="<?= $user->firstname; ?>" required>
+                    <input type="text" name="_firstname" id="firstname" class="floatLabel" value="<?= htmlspecialchars($user->firstname, ENT_QUOTES); ?>" required>
                     <label for="firstname" class="<?= empty($user->firstname) ?: 'active'; ?>">Prénom</label>
                 </div>
                 <div class="controls">
-                    <input type="text" name="_lastname" id="lastname" class="floatLabel" value="<?= $user->lastname; ?>" required>
+                    <input type="text" name="_lastname" id="lastname" class="floatLabel" value="<?= htmlspecialchars($user->lastname, ENT_QUOTES); ?>" required>
                     <label for="lastname" class="<?= empty($user->lastname) ?: 'active'; ?>">Nom</label>
                 </div>
                 <div class="controls">


### PR DESCRIPTION
## Résumé

Série de correctifs de sécurité suite à audit, groupés pour la version 26.5.3 :

- **2FA / session** : un rejet de double authentification détruit désormais
  réellement la session côté serveur (au lieu de ne retirer que deux clés
  `$_SESSION`), pour empêcher toute réutilisation d'une session restée
  authentifiée après un `_task=logout` non suivi par le client. Le cookie
  de mémorisation d'appareil `roundcube_doubleauth` est désactivé.
- **Traçabilité** : logs enrichis sur le contexte de connexion et
  l'orientation post-connexion, ainsi que sur les fins de session
  (explicites ou subies) via un nouveau hook `session_destroy`.
- **Path traversal** : nouveau `mel_helper::safe_require()` qui borne les
  `require_once` à chemin dynamique (driver Mél, driver de tâches) au
  dossier autorisé.
- **Désérialisation** : restriction `allowed_classes => false` sur les
  `unserialize()` de clés de calendrier.
- **Injection LDAP** : échappement (`ldap_escape`) et validation du format
  email avant toute recherche LDAP par email (`freebusy`, `extern/core.php`).
- **XSS réfléchi** : échappement HTML des valeurs utilisateur affichées
  dans les formulaires `forgotten`, `reinit`, `welcome`.
- **`mel_news`** : désactivation par défaut des fonctionnalités RSS et
  d'écriture/lecture de fichiers.
- **`mel_labels_sync`** : tolérance à l'échec de récupération des
  étiquettes (retourne une liste vide au lieu de planter).

## Pourquoi

Durcissement suite à un audit de sécurité : la session applicative devait
rester invalide après un échec de 2FA tant que le client ne suivait pas la
redirection de déconnexion ; plusieurs points d'entrée (chargement de
driver, désérialisation, recherche LDAP, formulaires publics) n'étaient
pas suffisamment validés/échappés.

## Comment tester

- Échouer une 2FA (mauvais code) puis, sans suivre la redirection, rejouer
  une requête authentifiée : elle doit être rejetée (session détruite
  côté serveur).
- Vérifier que le message d'échec de 2FA s'affiche bien sur la page de
  connexion après redirection.
- Consulter les logs `mel_logs` : présence des lignes `[login] Détail
  connexion`, `[login] Orientation après connexion` et `[logout]
  Déconnexion` avec les métadonnées attendues.
- Changer temporairement `mel_driver` vers une valeur invalide/hors dossier :
  `driver_mel::get_instance()` doit lever une erreur au lieu de charger un
  fichier arbitraire.
- `GET` sur l'ancien endpoint RSS de `mel_news` : doit répondre 404.
- Formulaires `forgotten`/`reinit`/`welcome` : vérifier l'absence
  d'injection HTML sur les champs pré-remplis.

## Impact

Aucune migration, aucun changement de schéma. Le cookie
`roundcube_doubleauth` n'étant plus utilisé, les utilisateurs devront de
nouveau valider leur 2FA (plus de mémorisation d'appareil).
