### PR TITLE
🚑  Améliorer la validation de l'image du bandeau du haut

### DIFF
--- a/plugins/mel_elastic/mel_elastic.php
+++ b/plugins/mel_elastic/mel_elastic.php
@@ -1,5 +1,6 @@
 <?php
-include_once __DIR__.'/../bnum/bnum_plugin.php';
+require_once __DIR__.'/../bnum/bnum_plugin.php';
+require_once __DIR__.'/program/mel_custom_picture.php';
 
 /**
  * Plugin Mel Elastic
@@ -494,7 +495,7 @@ class mel_elastic extends bnum_plugin
 
         // Récupère l'image de fond associée au thème actuel
         $picture = $this->rc->config->get('mel_elastic.picture.current', null);
-        if (isset($picture)) {
+        if (isset($picture) && mel_custom_picture::is_normalized($picture)) {
             // Définit l'image de fond sélectionnée dans l'environnement utilisateur
             $this->rc->output->set_env('theme_selected_picture', $picture);
         }
@@ -587,10 +588,63 @@ class mel_elastic extends bnum_plugin
      * @return void
      */
     public function update_custom_picture(){
-        $datas = rcube_utils::get_input_value('_datas', rcube_utils::INPUT_POST);
-        $pref = rcube_utils::get_input_value('_prefid', rcube_utils::INPUT_POST);
-        $this->rc->user->save_prefs(array($pref => $datas));
-        echo 'ok';
+        if (empty($this->rc->user->ID) || !$this->rc->check_request()) {
+            $this->_send_custom_picture_error('Requête invalide.', 403);
+            return;
+        }
+
+        $picture_id = (string) (rcube_utils::get_input_value('_id', rcube_utils::INPUT_POST) ?? '');
+        $pref = $this->_resolve_custom_picture_pref($picture_id);
+
+        if ($pref === null) {
+            $this->_send_custom_picture_error('Image inconnue.', 400);
+            return;
+        }
+
+        $raw = (string) (rcube_utils::get_input_value('_datas', rcube_utils::INPUT_POST) ?? '');
+
+        try {
+            $picture = mel_custom_picture::from_data_uri($raw);
+        } catch (mel_custom_picture_exception $ex) {
+            $this->_send_custom_picture_error($ex->getMessage(), 400);
+            return;
+        }
+
+        $normalized = $picture->to_data_uri();
+        $this->rc->user->save_prefs([$pref => $normalized]);
+
+        echo json_encode(['status' => 'ok', 'picture' => $normalized]);
+        exit;
+    }
+
+    /**
+     * Résout l'id de préférence associé à une image personnalisable.
+     *
+     * La liste blanche n'est pas dupliquée ici : elle est dérivée de la même
+     * source que l'env `mel_themes_pictures` envoyée au client. Un id d'image
+     * inconnu, ou une image sans `userprefid`, retourne null.
+     */
+    private function _resolve_custom_picture_pref(string $picture_id): ?string
+    {
+        if ($picture_id === '') {
+            return null;
+        }
+
+        $pictures = Background::from_path($this->skinPath.'/images/backgrounds/backgrounds.json');
+
+        if (!isset($pictures[$picture_id]['userprefid'])) {
+            return null;
+        }
+
+        $pref = (string) $pictures[$picture_id]['userprefid'];
+
+        return $pref === '' ? null : $pref;
+    }
+
+    private function _send_custom_picture_error(string $message, int $code)
+    {
+        header('HTTP/1.1 ' . $code);
+        echo json_encode(['status' => 'error', 'message' => $message]);
         exit;
     }
 

--- a/plugins/mel_elastic/program/mel_custom_picture.php
+++ b/plugins/mel_elastic/program/mel_custom_picture.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Image personnalisée refusée par la validation.
+ */
+class mel_custom_picture_exception extends RuntimeException
+{
+}
+
+/**
+ * Data-URI d'image validée et ré-encodée, prête à être stockée dans les
+ * préférences utilisateur et injectée dans du CSS.
+ *
+ * La seule façon d'obtenir une instance est `from_data_uri()`, qui rejette
+ * tout ce qui n'est pas une image décodable par GD. Les octets conservés
+ * sont ceux produits par GD, pas ceux reçus : tout ce qui n'est pas du pixel
+ * (métadonnées EXIF, données concaténées après la fin du format, fichiers
+ * polyglottes) disparaît au ré-encodage.
+ */
+final class mel_custom_picture
+{
+    /**
+     * Forme normalisée d'une image stockée. L'alphabet base64 ne contient ni
+     * quote, ni parenthèse, ni point-virgule : une valeur qui matche ce motif
+     * est injectable dans un `url(...)` CSS sans échappement supplémentaire.
+     */
+    private const NORMALIZED_PATTERN =
+        '#^data:image/(?:png|jpeg|gif|webp);base64,[A-Za-z0-9+/]+={0,2}$#';
+
+    /** Taille max de la chaîne reçue. Doit rester alignée avec le contrôle côté client. */
+    private const MAX_ENCODED_BYTES = 2097152;
+
+    private const MAX_SIDE = 4000;
+
+    /** Garde-fou contre les bombes de décompression (~32 Mo en truecolor GD). */
+    private const MAX_PIXELS = 8000000;
+
+    /** @var array<int, string> Types acceptés, du type réel détecté vers son mime. */
+    private const ALLOWED_TYPES = [
+        IMAGETYPE_PNG => 'image/png',
+        IMAGETYPE_JPEG => 'image/jpeg',
+        IMAGETYPE_GIF => 'image/gif',
+        IMAGETYPE_WEBP => 'image/webp',
+    ];
+
+    /** @var int Constante IMAGETYPE_* du contenu. */
+    private $type;
+
+    /** @var string Octets produits par GD. */
+    private $binary;
+
+    private function __construct(int $type, string $binary)
+    {
+        $this->type = $type;
+        $this->binary = $binary;
+    }
+
+    /**
+     * Valide une data-URI reçue du client et retourne l'image ré-encodée.
+     *
+     * @throws mel_custom_picture_exception Si l'entrée n'est pas une image
+     *                                     d'un des formats autorisés.
+     */
+    public static function from_data_uri(string $raw): self
+    {
+        // Avant tout décodage : la valeur part sérialisée dans la colonne
+        // `preferences` et sera relue à chaque page.
+        if (strlen($raw) > self::MAX_ENCODED_BYTES) {
+            throw new mel_custom_picture_exception('Image trop volumineuse.');
+        }
+
+        $matches = [];
+        if (!preg_match(self::NORMALIZED_PATTERN, $raw)
+            || !preg_match('#^data:(image/[a-z]+);base64,(.*)$#', $raw, $matches)
+        ) {
+            throw new mel_custom_picture_exception('Format de data-URI invalide.');
+        }
+
+        $declared_mime = $matches[1];
+        $binary = base64_decode($matches[2], true);
+
+        if ($binary === false || $binary === '') {
+            throw new mel_custom_picture_exception('Base64 invalide.');
+        }
+
+        $info = getimagesizefromstring($binary);
+
+        if ($info === false) {
+            throw new mel_custom_picture_exception('Contenu non reconnu comme image.');
+        }
+
+        $type = isset($info[2]) ? (int) $info[2] : 0;
+
+        if (!isset(self::ALLOWED_TYPES[$type])) {
+            throw new mel_custom_picture_exception('Format d\'image non autorisé.');
+        }
+
+        // Le mime annoncé dans la data-URI doit correspondre au contenu réel.
+        if (self::ALLOWED_TYPES[$type] !== $declared_mime) {
+            throw new mel_custom_picture_exception('Le type déclaré ne correspond pas au contenu.');
+        }
+
+        $width = (int) $info[0];
+        $height = (int) $info[1];
+
+        if ($width < 1 || $height < 1 || $width > self::MAX_SIDE || $height > self::MAX_SIDE) {
+            throw new mel_custom_picture_exception('Dimensions d\'image hors limites.');
+        }
+
+        // Contrôlé avant tout appel à GD : le décodeur est lui-même une surface
+        // d'attaque, on ne lui donne jamais une image aux dimensions non bornées.
+        if ($width * $height > self::MAX_PIXELS) {
+            throw new mel_custom_picture_exception('Image trop grande à décoder.');
+        }
+
+        return new self($type, self::reencode($binary, $type));
+    }
+
+    /**
+     * Vérifie qu'une valeur déjà stockée est sous forme normalisée.
+     *
+     * À utiliser sur le chemin de lecture : les préférences enregistrées avant
+     * ce correctif peuvent contenir n'importe quoi.
+     */
+    public static function is_normalized(?string $value): bool
+    {
+        return $value !== null
+            && strlen($value) <= self::MAX_ENCODED_BYTES
+            && preg_match(self::NORMALIZED_PATTERN, $value) === 1;
+    }
+
+    /**
+     * Data-URI normalisée, reconstruite depuis le mime de la liste blanche.
+     */
+    public function to_data_uri(): string
+    {
+        return 'data:' . self::ALLOWED_TYPES[$this->type] . ';base64,' . base64_encode($this->binary);
+    }
+
+    /**
+     * Décode puis ré-encode l'image, ne conservant que les pixels.
+     */
+    private static function reencode(string $binary, int $type): string
+    {
+        // `imagecreatefromstring` émet un warning au lieu de lever : on neutralise
+        // le handler le temps de l'appel plutôt que d'utiliser `@`.
+        set_error_handler(static function (): bool {
+            return true;
+        });
+
+        try {
+            $image = imagecreatefromstring($binary);
+        } finally {
+            restore_error_handler();
+        }
+
+        if ($image === false) {
+            throw new mel_custom_picture_exception('Image non décodable.');
+        }
+
+        ob_start();
+
+        try {
+            $written = self::write($image, $type);
+        } finally {
+            $output = (string) ob_get_clean();
+            imagedestroy($image);
+        }
+
+        if (!$written || $output === '') {
+            throw new mel_custom_picture_exception('Ré-encodage impossible.');
+        }
+
+        return $output;
+    }
+
+    /**
+     * Écrit l'image sur la sortie standard dans son format d'origine.
+     *
+     * @param resource|GdImage $image
+     */
+    private static function write($image, int $type): bool
+    {
+        switch ($type) {
+            case IMAGETYPE_PNG:
+                imagealphablending($image, false);
+                imagesavealpha($image, true);
+
+                return imagepng($image);
+
+            case IMAGETYPE_JPEG:
+                return imagejpeg($image, null, 85);
+
+            case IMAGETYPE_GIF:
+                // GD n'écrit qu'une frame : un GIF animé est aplati.
+                return imagegif($image);
+
+            case IMAGETYPE_WEBP:
+                if (!function_exists('imagewebp')) {
+                    throw new mel_custom_picture_exception('WebP non supporté par cette installation.');
+                }
+
+                imagealphablending($image, false);
+                imagesavealpha($image, true);
+
+                return imagewebp($image);
+
+            default:
+                return false;
+        }
+    }
+}

--- a/plugins/mel_elastic/program/mel_custom_picture.php
+++ b/plugins/mel_elastic/program/mel_custom_picture.php
@@ -144,6 +144,8 @@ final class mel_custom_picture
      */
     private static function reencode(string $binary, int $type): string
     {
+        self::require_functions(['imagecreatefromstring', 'imagedestroy']);
+
         // `imagecreatefromstring` émet un warning au lieu de lever : on neutralise
         // le handler le temps de l'appel plutôt que d'utiliser `@`.
         set_error_handler(static function (): bool {
@@ -185,22 +187,26 @@ final class mel_custom_picture
     {
         switch ($type) {
             case IMAGETYPE_PNG:
+                self::require_functions(['imagealphablending', 'imagesavealpha', 'imagepng']);
+
                 imagealphablending($image, false);
                 imagesavealpha($image, true);
 
                 return imagepng($image);
 
             case IMAGETYPE_JPEG:
+                self::require_functions(['imagejpeg']);
+
                 return imagejpeg($image, null, 85);
 
             case IMAGETYPE_GIF:
+                self::require_functions(['imagegif']);
+
                 // GD n'écrit qu'une frame : un GIF animé est aplati.
                 return imagegif($image);
 
             case IMAGETYPE_WEBP:
-                if (!function_exists('imagewebp')) {
-                    throw new mel_custom_picture_exception('WebP non supporté par cette installation.');
-                }
+                self::require_functions(['imagealphablending', 'imagesavealpha', 'imagewebp']);
 
                 imagealphablending($image, false);
                 imagesavealpha($image, true);
@@ -209,6 +215,28 @@ final class mel_custom_picture
 
             default:
                 return false;
+        }
+    }
+
+    /**
+     * Vérifie que les fonctions GD requises existent sur cette installation.
+     *
+     * GD est une extension optionnelle : certaines fonctions (notamment
+     * `imagewebp`) peuvent être absentes même quand l'extension est chargée,
+     * selon la version de la libgd liée au build de PHP.
+     *
+     * @param array<int, string> $functions Noms des fonctions GD requises.
+     *
+     * @throws mel_custom_picture_exception Si une fonction requise est absente.
+     */
+    private static function require_functions(array $functions): void
+    {
+        foreach ($functions as $function) {
+            if (!function_exists($function)) {
+                throw new mel_custom_picture_exception(
+                    "Fonction GD indisponible sur cette installation : {$function}()."
+                );
+            }
         }
     }
 }

--- a/skins/mel_elastic/ui.js
+++ b/skins/mel_elastic/ui.js
@@ -1212,7 +1212,18 @@ $(document).ready(() => {
       const CUSTOM_THEME_PARENT_DIV_CLASS = 'div-custom-picture px-1';
       const CUSTOM_THEME_CLASSES_PIC = 'half-resize';
       const INPUT_CLASS = 'hidden';
-      const INPUT_ACCEPT = ['.png', '.jpg', '.svg', '.gif'].join(',');
+      // Plus de SVG : script inline exécuté dans le contexte du Bnum + XXE au parsing.
+      const INPUT_ACCEPT = [
+        '.png',
+        '.jpg',
+        '.jpeg',
+        '.gif',
+        '.webp',
+        'image/png',
+        'image/jpeg',
+        'image/gif',
+        'image/webp',
+      ].join(',');
       const THEME_ATTRIB_DATA_USER_PREF_ID = 'prefid';
       const THEME_ATTRIB_DATA_PATH = 'picpath';
       const THEME_ATTRIB_DATA_ID = 'picid';
@@ -1270,52 +1281,54 @@ $(document).ready(() => {
             class: INPUT_CLASS,
             type: CONST_ATTRIB_TYPE_FILE,
             accept: INPUT_ACCEPT,
-            'data-prefid': iterator.value.userprefid,
+            // 'data-prefid': iterator.value.userprefid,
+            'data-picid': iterator.key,
           });
 
           //MAJ de l'image
           $input.onchange.push((ev) => {
             ev = $(ev.currentTarget);
-            const prefid = ev.data(THEME_ATTRIB_DATA_USER_PREF_ID);
+            const picid = ev.data('picid');
             const file = ev[0].files[0];
-            var reader = new FileReader();
-            reader.onload = (e) => {
-              const picture = e.target.result;
-              const size =
-                mel_metapage.Functions.calculateObjectSizeInMo(picture);
 
-              if (size < 2) {
-                this.update_custom_picture(picture, prefid);
-                let $selectable = ev
-                  .parent()
-                  .parent()
-                  .find(
-                    `${CONST_JQUERY_SELECTOR_CLASS}${CONST_CLASS_SELECTABLE}`,
-                  )
-                  .removeClass(THEME_DEFAULT_CLASS)
-                  .css(
-                    CONST_CSS_BACKGROUND_IMAGE,
-                    `${CONST_CSS_BACKGROUND_URL}(${picture})`,
-                  )
-                  .css(
-                    CONST_CSS_BACKGROUND_SIZE,
-                    CONST_CSS_BACKGROUND_SIZE_COVER,
-                  )
-                  .data(THEME_ATTRIB_DATA_PATH, picture)
-                  .data(THEME_ATTRIB_DATA_IS_CUSTOM, true);
+            if (!file) return;
 
-                if (
-                  $selectable.data(THEME_ATTRIB_DATA_ID) ===
-                  this.get_theme_picture()
-                ) {
-                  this.css_rules.remove(RULE_KEY);
-                  this._add_background(picture, true);
-                }
-              } else {
+            const reader = new FileReader();
+            reader.onload = async (e) => {
+              const local = e.target.result;
+
+              // Pré-filtre de confort uniquement : la limite qui compte est côté serveur.
+              if (mel_metapage.Functions.calculateObjectSizeInMo(local) >= 2) {
                 rcmail.display_message(
                   'Votre image est trop lourde !',
                   'error',
                 );
+                return;
+              }
+
+              const picture = await this.update_custom_picture(local, picid);
+
+              if (!picture) return;
+
+              const $selectable = ev
+                .parent()
+                .parent()
+                .find(`${CONST_JQUERY_SELECTOR_CLASS}${CONST_CLASS_SELECTABLE}`)
+                .removeClass(THEME_DEFAULT_CLASS)
+                .css(
+                  CONST_CSS_BACKGROUND_IMAGE,
+                  `${CONST_CSS_BACKGROUND_URL}(${picture})`,
+                )
+                .css(CONST_CSS_BACKGROUND_SIZE, CONST_CSS_BACKGROUND_SIZE_COVER)
+                .data(THEME_ATTRIB_DATA_PATH, picture)
+                .data(THEME_ATTRIB_DATA_IS_CUSTOM, true);
+
+              if (
+                $selectable.data(THEME_ATTRIB_DATA_ID) ===
+                this.get_theme_picture()
+              ) {
+                this.css_rules.remove(RULE_KEY);
+                this._add_background(picture, true);
               }
             };
             reader.readAsDataURL(file);
@@ -1496,26 +1509,60 @@ $(document).ready(() => {
       return this;
     }
 
-    async update_custom_picture(datas, pref) {
+    /**
+     * Envoie une image personnalisée et retourne la data-URI normalisée par le
+     * serveur, ou null si elle a été refusée.
+     *
+     * @param {string} datas Data-URI lue localement
+     * @param {string} picid Id de l'image à personnaliser
+     * @returns {Promise<?string>}
+     */
+    async update_custom_picture(datas, picid) {
+      let normalized = null;
+
       await mel_metapage.Functions.post(
         mel_metapage.Functions.url(
           'mel_metapage',
           'plugin.update_custom_picture',
         ),
-        {
-          _datas: datas,
-          _prefid: pref,
-        },
-        (datas) => {
-          const VALIDATION = 'ok';
-          if (VALIDATION === datas) {
+        { _datas: datas, _id: picid },
+        (response) => {
+          const parsed =
+            typeof response === 'string' ? JSON.parse(response) : response;
+
+          if (parsed?.status === 'ok') {
+            normalized = parsed.picture;
             rcmail.display_message(
               'Image chargée avec succès !',
               'confirmation',
             );
+          } else {
+            rcmail.display_message(
+              parsed?.message || "Impossible de charger l'image.",
+              'error',
+            );
           }
         },
+        (failed) => {
+          let data = null;
+
+          try {
+            data = JSON.parse(failed.responseText);
+          } catch (error) {
+            console.info(
+              'update_custom_picture',
+              'unable to parse : ',
+              failed?.responseText,
+            );
+            data = failed?.responseText || null;
+          }
+
+          if (data && data.message)
+            rcmail.display_message(data.message, 'error');
+        },
       );
+
+      return normalized;
     }
 
     async set_theme_picture(id) {


### PR DESCRIPTION
Durcissement de la gestion des images personnalisées du bandeau du haut (`mel_elastic`) :

- Ajout de la classe `mel_custom_picture` (`plugins/mel_elastic/program/mel_custom_picture.php`) qui valide et ré-encode toute image reçue :
  - liste blanche de formats (`PNG`, `JPEG`, `GIF`, `WEBP`) — **SVG retiré** (script inline exécuté dans le contexte Bnum + risque XXE au parsing) ;
  - vérification que le mime déclaré correspond au contenu réel détecté ;
  - limites de taille encodée, de dimensions et de nombre de pixels (garde-fou contre les bombes de décompression) ;
  - ré-encodage via GD : seuls les pixels sont conservés, toute métadonnée ou donnée concaténée après la fin du format disparaît.
- `mel_elastic::update_custom_picture()` :
  - ajout du contrôle CSRF (`check_request()`) et vérification que l'utilisateur est authentifié ;
  - l'id de préférence (`pref`) n'est plus fourni tel quel par le client : il est résolu côté serveur à partir de l'id d'image (`_id`), via la liste blanche déjà exposée au client (`backgrounds.json`) — empêche l'écriture d'une préférence arbitraire ;
  - réponse JSON structurée (`status`/`message`/`picture`) au lieu d'un simple `'ok'` en texte brut.
- Lecture de la préférence utilisateur : l'image stockée n'est réinjectée dans l'environnement (`theme_selected_picture`) que si elle est reconnue comme normalisée (`mel_custom_picture::is_normalized()`) — protège contre d'anciennes valeurs invalides déjà en base.
- Front (`skins/mel_elastic/ui.js`) : accept file retiré du SVG, ajout du WEBP, envoi de l'id d'image (`picid`) au lieu du `prefid`, prise en compte de la data-URI normalisée renvoyée par le serveur, affichage des erreurs retournées par l'API.
- `mel_elastic.php` : passage de `include_once` à `require_once` pour la dépendance `bnum_plugin`.

## Pourquoi

L'ancienne implémentation acceptait n'importe quel fichier déclaré comme image (SVG inclus), stockait la data-URI brute reçue du client sans validation serveur, et laissait le client choisir librement la clé de préférence (`_prefid`) à écrire — surface d'attaque XSS/XXE (SVG) et d'écriture de préférence arbitraire.

## Comment tester

1. Se connecter avec la skin `mel_elastic` active.
2. Personnaliser l'image du bandeau du haut avec un PNG/JPEG/GIF/WEBP valide → l'image doit s'appliquer et être conservée après rechargement.
3. Tenter d'envoyer un SVG → doit être rejeté côté client (non proposé dans le sélecteur de fichier) et côté serveur si forcé.
4. Tenter d'envoyer un fichier non-image renommé en `.png`, ou une image dépassant les limites de taille/dimensions → message d'erreur affiché, aucune préférence modifiée.
5. Vérifier qu'une requête `update_custom_picture` sans jeton CSRF valide est rejetée (403).
6. Vérifier qu'un compte existant avec une ancienne valeur non conforme en préférence ne casse pas l'affichage (pas de `theme_selected_picture` injecté si non normalisé).
