### PR TITLE
:ambulance: Correctifs de sécurités

### DIFF
--- a/login.php
+++ b/login.php
@@ -117,7 +117,7 @@ function get_address_ip() {
  * Permet la selection de la bonne url
  */
 function is_internal() {
-  return (!isset($_SERVER["HTTP_X_MINEQPROVENANCE"]) || strcasecmp($_SERVER["HTTP_X_MINEQPROVENANCE"], "intranet") === 0);
+  return (isset($_SERVER["HTTP_X_MINEQPROVENANCE"]) && strcasecmp($_SERVER["HTTP_X_MINEQPROVENANCE"], "intranet") === 0);
 }
 
 /**

--- a/plugins/mel_news/lib/news_datas.php
+++ b/plugins/mel_news/lib/news_datas.php
@@ -149,7 +149,7 @@ class news_datas extends anews_datas
         $model = str_replace("<datacopy/>", "", $model);
         $model = str_replace("<dataformat/>", "small", $model);
         $model = str_replace("<datatype/>", $this->_service, $model);
-        $model = str_replace("<title/>", $this->title, $model);
+        $model = str_replace("<title/>", html::quote($this->title), $model);
         $model = str_replace("<headlines_other_classes/>", "", $model);
         $model = str_replace("<text/>", $this->text, $model);
         $model = str_replace("<date/>", $this->tradDate($this->date->getFullDate($plugin), $plugin), $model);

--- a/plugins/mel_news/mel_news.php
+++ b/plugins/mel_news/mel_news.php
@@ -455,7 +455,7 @@ class mel_news extends rcube_plugin {
     }
 
     $news->title = rcube_utils::get_input_value("_title", rcube_utils::INPUT_POST);
-    $news->description = rcube_utils::get_input_value("_description", rcube_utils::INPUT_POST, true);
+    $news->description = mel_helper::wash_html(rcube_utils::get_input_value("_description", rcube_utils::INPUT_POST, true));
     $news->modified = date('Y-m-d H:i:s');
     $news->service = $service;
     $news->service_name = explode('=', explode(',', $service, 2)[0])[1];

--- a/plugins/roundrive/lib/roundrive_collabora.php
+++ b/plugins/roundrive/lib/roundrive_collabora.php
@@ -57,7 +57,17 @@ class roundrive_collabora
     private function create_document($path, $name, $ext, $model)
     {
         $dir = __DIR__;
-        $doc = fopen("$dir/../files/$model.$ext", 'r');
+
+        $model = basename($model);
+        $files_dir = realpath("$dir/../files");
+        $file = realpath("$dir/../files/$model.$ext");
+
+        if ($files_dir === false || 
+            $file === false      || 
+            strpos($file, $files_dir . DIRECTORY_SEPARATOR) !== 0) return false;
+        
+        $doc = fopen($file, 'r');
+
         return $this->filesystem->putStream("$path/$name.$ext", $doc);
     }
 


### PR DESCRIPTION
## Contexte

Correctifs de sécurité et de logique regroupés pour la branche `dwp-26.5.3`, sur `login.php`, `mel_news` et `roundrive`.

## Changements

- 🐛 **`login.php`** — correction de la logique de `is_internal()` : la fonction considérait par défaut une requête comme interne dès que l'en-tête `HTTP_X_MINEQPROVENANCE` était absent. Elle exige désormais explicitement que l'en-tête soit présent **et** valorisé à `intranet`.
- 🐛 **`roundrive_collabora.php`** — validation des chemins de fichiers dans `create_document()` (`basename()` sur le nom de modèle + vérification via `realpath()` que le fichier résolu reste bien dans le dossier `files/` attendu) pour empêcher une traversée de répertoire (directory traversal).
- 🐛 **`mel_news` (`news_datas.php`)** — échappement du titre via `html::quote()` avant injection dans le template, pour prévenir une injection XSS.
- 🚑️ **`mel_news` (`mel_news.php`)** — passage de l'entrée `_description` du formulaire par `mel_helper::wash_html()` avant stockage, pour prévenir une injection XSS.

## Points d'attention pour la revue

- Le changement sur `is_internal()` inverse le comportement par défaut (fail-closed au lieu de fail-open) : à vérifier que les environnements/proxys sans en-tête `HTTP_X_MINEQPROVENANCE` sont bien couverts en amont, sinon ils basculeront vers l'URL "externe".