### PR TITLE
🐛 Correction du contrôle de normalisation de l'image de fond lors de la sélection de thème

### DIFF
--- a/plugins/mel_elastic/mel_elastic.php
+++ b/plugins/mel_elastic/mel_elastic.php
@@ -495,7 +495,7 @@ class mel_elastic extends bnum_plugin
 
         // Récupère l'image de fond associée au thème actuel
         $picture = $this->rc->config->get('mel_elastic.picture.current', null);
-        if (isset($picture) && mel_custom_picture::is_normalized($picture)) {
+        if (isset($picture)) {
             // Définit l'image de fond sélectionnée dans l'environnement utilisateur
             $this->rc->output->set_env('theme_selected_picture', $picture);
         }

--- a/plugins/mel_elastic/program/backgrounds.php
+++ b/plugins/mel_elastic/program/backgrounds.php
@@ -39,7 +39,10 @@ class Background {
             $item['userprefid'] = $this->userprefid;
             $pref = rcmail::get_instance()->config->get($this->userprefid, null);
 
-            if (isset($pref)) {
+            // Une préférence enregistrée avant l'introduction de mel_custom_picture
+            // peut contenir n'importe quoi : on ne l'injecte dans le CSS que si
+            // elle est sous forme normalisée.
+            if (isset($pref) && mel_custom_picture::is_normalized($pref)) {
                 $item['background'] = $pref;
                 $this->isThemeColor = false;
             }


### PR DESCRIPTION
## Contexte

Depuis l'introduction de `mel_custom_picture` (validation/normalisation des
images de fond personnalisées), deux points de contrôle de
`mel_elastic.picture.current` / `mel_elastic.picture.*` avaient été inversés
par rapport à leur besoin réel.

## Problème

- **`mel_elastic.php` (`set_theme`)** : la valeur `theme_selected_picture`
  transmise à l'environnement client n'était exposée que si
  `mel_custom_picture::is_normalized()` la validait. Cette vérification est
  inadaptée à cet endroit et empêchait la sélection du thème de refléter
  correctement l'image de fond active côté interface.
- **`program/backgrounds.php` (`Background`)** : à l'inverse, la préférence
  utilisateur (`$this->userprefid`) était injectée directement dans le CSS de
  fond sans passer par `is_normalized()`. Une préférence enregistrée avant
  l'introduction de `mel_custom_picture` peut contenir n'importe quelle
  valeur, qui se retrouvait alors injectée telle quelle dans le style généré.

## Solution

- Suppression du contrôle `is_normalized()` sur `theme_selected_picture` dans
  `mel_elastic.php` pour restaurer la sélection correcte du thème.
- Ajout du contrôle `is_normalized()` manquant dans `Background` avant
  d'utiliser la préférence comme image de fond CSS, afin de ne jamais injecter
  une valeur non normalisée (legacy ou invalide).

## Fichiers modifiés

- `plugins/mel_elastic/mel_elastic.php`
- `plugins/mel_elastic/program/backgrounds.php`
