### PR TITLE
587 - :bug: move API key to Authorization Bearer header

### DIFF
--- a/plugins/mel/lib/drivers/mce/mce.php
+++ b/plugins/mel/lib/drivers/mce/mce.php
@@ -559,8 +559,9 @@ class mce_driver_mel extends driver_mel
     // Requête http à l'API
     $ch = curl_init();
     curl_setopt_array($ch, [
-      CURLOPT_URL => $this->get_restoration_api_url($mbox) . '/dir?key=' . $this->_restoration_api_key . '&user=' . $mbox,
-      CURLOPT_RETURNTRANSFER => 1
+      CURLOPT_URL => $this->get_restoration_api_url($mbox) . '/dir?user=' . $mbox,
+      CURLOPT_RETURNTRANSFER => 1,
+      CURLOPT_HTTPHEADER => ['Authorization: Bearer ' . $this->_restoration_api_key,],
     ]);
     $output = curl_exec($ch);
     if ($output === false) {


### PR DESCRIPTION
### Modification

Modification de l'appel API afin de ne plus transmettre la api_key en paramètre de requête.

La clé est désormais envoyée dans le header HTTP d'authentification :
Authorization: Bearer <api_key>

Closes #587 