### PR TITLE
590 - :bug:  Ajouter le protocole https pour l'api de restoration

### DIFF
--- a/plugins/mel/lib/drivers/mce/mce.php
+++ b/plugins/mel/lib/drivers/mce/mce.php
@@ -304,7 +304,7 @@ class mce_driver_mel extends driver_mel
     // Récupération de la configuration de la boite pour l'affichage
     $host = $this->get_restoration_host($mbox);
 
-    return $host . ":" . $this->_restoration_api_port;
+    return 'https://' . $host . ":" . $this->_restoration_api_port;
   }
 
   /**


### PR DESCRIPTION
### Contexte

L'URL utilisée pour appeler l'API ne contient pas le protocole `https`, ce qui entraîne une erreur lors de l'appel.

### Modification

Ajout du protocole `https` à l'URL de l'API afin de garantir que les requêtes soient effectuées correctement en HTTPS.

### Résultat attendu

Les appels à l'API fonctionnent correctement avec une URL complète utilisant le protocole `https`.

Closes #590 