### PR TITLE
592 - :bug:  update datetimepicker asset references

### DIFF
--- a/plugins/mel_moncompte/skins/mel_elastic/templates/m2_resource_mailbox.html
+++ b/plugins/mel_moncompte/skins/mel_elastic/templates/m2_resource_mailbox.html
@@ -17,7 +17,7 @@
 		margin-bottom: 0;
 	}
 </style>
-<link rel="stylesheet" type="text/css" href="plugins/mel_moncompte/jquery.datetimepicker.css">
+<link rel="stylesheet" type="text/css" href="skins/mel_elastic/jquery.datetimepicker.css">
 <framed_item>
 <div class="framed_item">
 	<div id="preferences-details" class="boxcontent">
@@ -54,7 +54,7 @@
 				<roundcube:label name="mel_moncompte.restore_bal" />
 			</div>
 			<roundcube:object name="restore_bal"/>
-			<script src="plugins/mel_moncompte/jquery.datetimepicker.full.min.js"></script>
+			<script src="skins/mel_elastic/jquery.datetimepicker.full.min.js"></script>
 			<script>
 			$(function () {
 


### PR DESCRIPTION
### Modification

Mise à jour des références des assets du `datetimepicker` afin d'utiliser le chemin correct vers les fichiers CSS.

### Changement effectué

Remplacement de l'ancienne référence :

`.../jquery.datetimepicker.css`

par :

`skins/mel_elastic/jquery.datetimepicker.css`

### Résultat attendu

Le fichier CSS du `datetimepicker` est désormais correctement chargé depuis le skin `mel_elastic`.


Closes #592 